### PR TITLE
fix(report-dashboard-widget): table content cells are now right-aligned

### DIFF
--- a/migrated-hub-widgets/report-dashboard-widgets/widgets/index.html
+++ b/migrated-hub-widgets/report-dashboard-widgets/widgets/index.html
@@ -28,6 +28,10 @@
         font-size: var(--ring-font-size);
         line-height: var(--ring-line-height);
       }
+
+      body.widgetBody table > tbody > tr > td {
+        text-align: right;
+      }
     </style>
   <script defer src="main-dfbdd2750b449b434663.js?dfbdd2750b449b434663"></script></head>
   <body class="widgetBody">


### PR DESCRIPTION
This makes them consistent with the theming shown in the report designer.

Fixes #20 