### PR TITLE
Improve extension properties template selection

### DIFF
--- a/packages/create-youtrack-app/_templates/extension-property/add/index.js
+++ b/packages/create-youtrack-app/_templates/extension-property/add/index.js
@@ -1,6 +1,19 @@
 const { injectJSCallback } = require("../../injectJsCallback");
+const entities = require("@jetbrains/youtrack-scripting-api/entities");
 const fs = require("node:fs");
 const path = require("node:path");
+
+const entitiesTypes = Object.keys(entities).map((entity) => ({
+  name: entity,
+  message: entity,
+}));
+
+const primitiveTypes = ["String", "Integer", "Float", "Boolean"].map(
+  (type) => ({
+    name: type.toLowerCase(),
+    message: type,
+  })
+);
 
 module.exports = {
   prompt: injectJSCallback(injectEntity, ({ prompter, args }) =>
@@ -11,36 +24,30 @@ module.exports = {
         message: "What is the name of the extension property",
       },
       {
-        type: "select",
+        type: "autocomplete",
         name: "type",
         message: "What is the type of the extension property",
-        choices: [
-          {
-            name: "string",
-            message: "String",
-          },
-          { name: "integer", message: "Integer" },
-          { name: "boolean", message: "Boolean" },
-          {
-            name: "Issue",
-            message: "Issue",
-          },
-        ],
+        limit: 6,
+        choices: [...primitiveTypes, ...entitiesTypes],
       },
       {
         type: "confirm",
         name: "isSet",
         message: "Is it a set of values?",
+        skip() {
+          return primitiveTypes.some(
+            (primitive) => primitive.name === this.state.answers.type
+          );
+        },
       },
       {
-        type: "select",
+        type: "autocomplete",
         name: "target",
         message: "What is the target extending entity?",
+        limit: 6,
         choices: [
-          { name: "Issue", message: "Issue" },
-          { name: "Comment", message: "Comment" },
-          { name: "User", message: "User" },
           { name: "AppGlobalStorage", message: "Global Storage" },
+          ...entitiesTypes,
         ],
       },
     ]),

--- a/packages/create-youtrack-app/package.json
+++ b/packages/create-youtrack-app/package.json
@@ -35,7 +35,8 @@
     "enquirer": "^2.4.1",
     "execa": "^5.0.0",
     "hygen": "^6.2.11",
-    "minimist": "^1.2.8"
+    "minimist": "^1.2.8",
+    "@jetbrains/youtrack-scripting-api": "^2022.1.46592"
   },
   "devDependencies": {
     "@biomejs/biome": "1.8.3",


### PR DESCRIPTION
Updated the extension properties template to align with [YouTrack documentation](https://www.jetbrains.com/help/youtrack/devportal/apps-extension-properties.html):

- Added support for the primitive type `float`, which was previously missing.
- Enabled selection of any available YouTrack entity as a type.
- Replaced the "select" input with "autocomplete" for easier searching and selection.
- Restricted the "Is it a set of values?" option to non-primitive types, as per documentation.
- Expanded "What is the target extending entity?" to include all YouTrack entities.