### PR TITLE
feat(ci): add tag-based publish to npm

### DIFF
--- a/packages/create-youtrack-app/package.json
+++ b/packages/create-youtrack-app/package.json
@@ -26,7 +26,7 @@
     "generate:test": "bash scripts/generate-test-app.sh",
     "test": "bash scripts/generate-and-test.sh",
     "build": "echo 'no build required'",
-    "release:ci": "commit-and-tag-version --release-as patch && git push --follow-tags origin main && npm publish"
+    "release:ci": "bash scripts/release-ci.sh"
   },
   "author": "Andrey Skladchikov",
   "license": "Apache-2.0",

--- a/packages/create-youtrack-app/scripts/release-ci.sh
+++ b/packages/create-youtrack-app/scripts/release-ci.sh
@@ -13,15 +13,17 @@ if [ "${NPM_DIST_TAG:-}" != "" ]; then
   TAG_RAW="$NPM_DIST_TAG"
   # Sanitize dist-tag for npm/version prerelease id compatibility
   # Keep alnum, dot and dash; convert slashes/underscores/spaces to dash
+  # NPM dist-tags must not contain slashes, underscores, or spaces; these are replaced with dashes ('-') for compatibility.
+  # The 'tr' command replaces each of '/', '_', and ' ' with '-', ensuring the tag is valid for npm publish.
   TAG_SANITIZED="$(echo "$TAG_RAW" | tr '/_ ' '---' | tr -cd '[:alnum:].-')"
-  PRERELEASE_ID="$TAG_SANITIZED"
 
-  echo "Tagged release (NPM_DIST_TAG='${TAG_RAW}', prerelease id='${PRERELEASE_ID}')."
+
+  echo "Tagged release (NPM_DIST_TAG='${TAG_RAW}', prerelease id='${TAG_SANITIZED}')."
   echo "Creating prerelease and publishing under dist-tag '${TAG_SANITIZED}' (latest won't be affected)."
 
-  npx commit-and-tag-version --prerelease "$PRERELEASE_ID"
+  npx commit-and-tag-version --prerelease "$TAG_SANITIZED"
 
-  git push --follow-tags
+  git push --follow-tags origin "$BRANCH"
 
   npm publish --tag "$TAG_SANITIZED"
 

--- a/packages/create-youtrack-app/scripts/release-ci.sh
+++ b/packages/create-youtrack-app/scripts/release-ci.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+PKG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cd "$PKG_DIR"
+
+# Read current version from package.json (no jq dependency)
+CURRENT_VERSION="$(node -p "require('./package.json').version")"
+
+if [ "${NPM_DIST_TAG:-}" != "" ]; then
+  TAG_RAW="$NPM_DIST_TAG"
+  # Sanitize dist-tag for npm/version prerelease id compatibility
+  # Keep alnum, dot and dash; convert slashes/underscores/spaces to dash
+  TAG_SANITIZED="$(echo "$TAG_RAW" | tr '/_ ' '---' | tr -cd '[:alnum:].-')"
+  PRERELEASE_ID="$TAG_SANITIZED"
+
+  echo "Tagged release (NPM_DIST_TAG='${TAG_RAW}', prerelease id='${PRERELEASE_ID}')."
+  echo "Creating prerelease and publishing under dist-tag '${TAG_SANITIZED}' (latest won't be affected)."
+
+  npx commit-and-tag-version --prerelease "$PRERELEASE_ID"
+
+  git push --follow-tags
+
+  npm publish --tag "$TAG_SANITIZED"
+
+else
+  if [ "$BRANCH" = "main" ]; then
+    echo "Main release (no NPM_DIST_TAG): bumping patch and publishing as 'latest'."
+    npx commit-and-tag-version --release-as patch
+    git push --follow-tags origin main
+    npm publish
+  else
+    echo "Refusing to publish from non-main without NPM_DIST_TAG. Branch: '$BRANCH', version: '$CURRENT_VERSION'."
+    echo "Set NPM_DIST_TAG (e.g., 'experimental') to create a tagged prerelease that won't move 'latest'."
+    exit 1
+  fi
+fi


### PR DESCRIPTION
I've added a mechanism to run a tagged release from the branch when we have $$NPM_DIST_TAG in the environment.
With this approach we can run our CI pipeline from a branch with the specific tag and it will be published to npm without moving the `latest` tag