### PR TITLE
feat(webhook-triggers-app): address security concerns

### DIFF
--- a/packages/webhook-triggers-app/src/settings.json
+++ b/packages/webhook-triggers-app/src/settings.json
@@ -3,11 +3,11 @@
   "type": "object",
   "title": "Webhook Triggers Settings",
   "description": "Trigger external webhooks from YouTrack events such as issue creation, updates, deletion, comments (add/edit/delete), work items (add/edit/delete), and attachments (add/remove). Configure multiple webhook URLs per event in the project settings.",
-  "required": ["webhookToken", "headerName"],
+  "required": ["headerName"],
   "properties": {
     "webhookToken": {
-      "title": "Webhook token",
-      "description": "The webhook token is a shared secret included in requests to all webhook URLs configured in this project. Only add endpoints you trust. Rotate this token immediately if any recipient is decommissioned or a compromise is suspected. Must be at least 32 characters long.",
+      "title": "Default webhook token",
+      "description": "Used for any webhook URL that does not have its own token. If multiple URLs rely on this default token, they all use the same secret, so if one is compromised, the others are too. For better security, add a token to each URL instead, for example: https://example.com mytoken",
       "type": "string",
       "format": "secret",
       "x-scope": "PROJECT"
@@ -22,88 +22,87 @@
     },
     "webhooksOnIssueCreated": {
       "title": "Issue created",
-      "description": "Triggered when a new issue is created",
+      "description": "Triggered when a new issue is created. Enter one URL per line or separate multiple URLs with commas. To use a token for a specific webhook, add it after the URL, separated by a space. For example: https://example.com/hook mytoken",
       "type": "string",
       "format": "textarea",
       "x-scope": "PROJECT"
     },
     "webhooksOnIssueUpdated": {
       "title": "Issue updated",
-      "description": "Triggered when an issue is modified",
+      "description": "Triggered when an issue is modified. Enter one URL per line or separate multiple URLs with commas. To use a token for a specific webhook, add it after the URL, separated by a space. For example: https://example.com/hook mytoken",
       "type": "string",
       "format": "textarea",
       "x-scope": "PROJECT"
     },
     "webhooksOnIssueDeleted": {
       "title": "Issue deleted",
-      "description": "Triggered when an issue is removed",
+      "description": "Triggered when an issue is removed. Enter one URL per line or separate multiple URLs with commas. To use a token for a specific webhook, add it after the URL, separated by a space. For example: https://example.com/hook mytoken",
       "type": "string",
       "format": "textarea",
       "x-scope": "PROJECT"
     },
     "webhooksOnCommentAdded": {
       "title": "Comment added",
-      "description": "Triggered when a comment is added to an issue",
+      "description": "Triggered when a comment is added to an issue. Enter one URL per line or separate multiple URLs with commas. To use a token for a specific webhook, add it after the URL, separated by a space. For example: https://example.com/hook mytoken",
       "type": "string",
       "format": "textarea",
       "x-scope": "PROJECT"
     },
     "webhooksOnCommentUpdated": {
       "title": "Comment updated",
-      "description": "Triggered when a comment is modified",
+      "description": "Triggered when a comment is modified. Enter one URL per line or separate multiple URLs with commas. To use a token for a specific webhook, add it after the URL, separated by a space. For example: https://example.com/hook mytoken",
       "type": "string",
       "format": "textarea",
       "x-scope": "PROJECT"
     },
     "webhooksOnCommentDeleted": {
       "title": "Comment deleted",
-      "description": "Triggered when a comment is removed",
+      "description": "Triggered when a comment is removed. Enter one URL per line or separate multiple URLs with commas. To use a token for a specific webhook, add it after the URL, separated by a space. For example: https://example.com/hook mytoken",
       "type": "string",
       "format": "textarea",
       "x-scope": "PROJECT"
     },
     "webhooksOnAttachmentAdded": {
       "title": "Attachment added",
-      "description": "Triggered when an attachment is added to an issue",
+      "description": "Triggered when an attachment is added to an issue. Enter one URL per line or separate multiple URLs with commas. To use a token for a specific webhook, add it after the URL, separated by a space. For example: https://example.com/hook mytoken",
       "type": "string",
       "format": "textarea",
       "x-scope": "PROJECT"
     },
     "webhooksOnAttachmentDeleted": {
       "title": "Attachment deleted",
-      "description": "Triggered when an attachment is removed",
+      "description": "Triggered when an attachment is removed. Enter one URL per line or separate multiple URLs with commas. To use a token for a specific webhook, add it after the URL, separated by a space. For example: https://example.com/hook mytoken",
       "type": "string",
       "format": "textarea",
       "x-scope": "PROJECT"
     },
     "webhooksOnWorkItemAdded": {
       "title": "Work item added",
-      "description": "Triggered when time is logged on an issue",
+      "description": "Triggered when time is logged on an issue. Enter one URL per line or separate multiple URLs with commas. To use a token for a specific webhook, add it after the URL, separated by a space. For example: https://example.com/hook mytoken",
       "type": "string",
       "format": "textarea",
       "x-scope": "PROJECT"
     },
     "webhooksOnWorkItemUpdated": {
       "title": "Work item updated",
-      "description": "Triggered when a work item is modified",
+      "description": "Triggered when a work item is modified. Enter one URL per line or separate multiple URLs with commas. To use a token for a specific webhook, add it after the URL, separated by a space. For example: https://example.com/hook mytoken",
       "type": "string",
       "format": "textarea",
       "x-scope": "PROJECT"
     },
     "webhooksOnWorkItemDeleted": {
       "title": "Work item deleted",
-      "description": "Triggered when a work item is removed",
+      "description": "Triggered when a work item is removed. Enter one URL per line or separate multiple URLs with commas. To use a token for a specific webhook, add it after the URL, separated by a space. For example: https://example.com/hook mytoken",
       "type": "string",
       "format": "textarea",
       "x-scope": "PROJECT"
     },
     "webhooksOnAllEvents": {
       "title": "All events",
-      "description": "Triggered on any event (issue created/updated/deleted, comments, attachments, work items)",
+      "description": "Triggered on any event (issue created/updated/deleted, comments, attachments, work items). Enter one URL per line or separate multiple URLs with commas. To use a token for a specific webhook, add it after the URL, separated by a space. For example: https://example.com/hook mytoken",
       "type": "string",
       "format": "textarea",
       "x-scope": "PROJECT"
     }
   }
 }
-

--- a/packages/webhook-triggers-app/src/settings.json
+++ b/packages/webhook-triggers-app/src/settings.json
@@ -10,7 +10,8 @@
       "description": "Used for any webhook URL that does not have its own token. If multiple URLs rely on this default token, they all use the same secret, so if one is compromised, the others are too. For better security, add a token to each URL instead, for example: https://example.com mytoken",
       "type": "string",
       "format": "secret",
-      "x-scope": "PROJECT"
+      "x-scope": "PROJECT",
+      "minLength": 32
     },
     "headerName": {
       "title": "Header name",

--- a/packages/webhook-triggers-app/src/workflows/__tests__/workflow-http.test.js
+++ b/packages/webhook-triggers-app/src/workflows/__tests__/workflow-http.test.js
@@ -172,7 +172,7 @@ describe('getWebhookEntries', () => {
     ]);
   });
 
-  it('deduplicates: event-specific no-token wins over all-events token when event-specific is listed first', () => {
+  it('deduplicates: all-events token is kept when event-specific entry has no token (token-wins)', () => {
     const ctx = {
       settings: {
         webhooksOnIssueCreated: 'https://a.com',
@@ -180,7 +180,19 @@ describe('getWebhookEntries', () => {
       },
     };
     expect(getWebhookEntries(ctx, 'webhooksOnIssueCreated')).toEqual([
-      { url: 'https://a.com', token: null },
+      { url: 'https://a.com', token: 'token_all' },
+    ]);
+  });
+
+  it('deduplicates: event-specific token wins when both entries have an explicit token', () => {
+    const ctx = {
+      settings: {
+        webhooksOnIssueCreated: 'https://a.com token_specific',
+        webhooksOnAllEvents: 'https://a.com token_all',
+      },
+    };
+    expect(getWebhookEntries(ctx, 'webhooksOnIssueCreated')).toEqual([
+      { url: 'https://a.com', token: 'token_specific' },
     ]);
   });
 

--- a/packages/webhook-triggers-app/src/workflows/__tests__/workflow-http.test.js
+++ b/packages/webhook-triggers-app/src/workflows/__tests__/workflow-http.test.js
@@ -1,7 +1,16 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 // @jetbrains/youtrack-scripting-api/http is stubbed by setup.js via
 // Module._resolveFilename so workflow-http.js loads without YouTrack runtime.
-import { parseWebhookUrls, sendWebhook } from '../workflow-http.js';
+import {
+  parseWebhookUrls,
+  parseWebhookEntries,
+  getWebhookEntries,
+  sendWebhook,
+  sendWebhooks,
+} from '../workflow-http.js';
+import { createRequire } from 'module';
+const _require = createRequire(import.meta.url);
+const httpMock = _require('./mocks/youtrack-http.cjs');
 
 // ── parseWebhookUrls ──────────────────────────────────────────────────────────
 
@@ -53,6 +62,141 @@ describe('parseWebhookUrls', () => {
     expect(parseWebhookUrls('https://a.com/,,\n\nhttps://b.com/')).toEqual([
       'https://a.com/',
       'https://b.com/',
+    ]);
+  });
+});
+
+// ── parseWebhookEntries ───────────────────────────────────────────────────────
+
+describe('parseWebhookEntries', () => {
+  it('returns [] for empty string', () => {
+    expect(parseWebhookEntries('')).toEqual([]);
+  });
+
+  it('returns [] for null', () => {
+    expect(parseWebhookEntries(null)).toEqual([]);
+  });
+
+  it('returns [] for undefined', () => {
+    expect(parseWebhookEntries(undefined)).toEqual([]);
+  });
+
+  it('returns [] for a non-string', () => {
+    expect(parseWebhookEntries(42)).toEqual([]);
+  });
+
+  it('parses a URL-only line — token is null', () => {
+    expect(parseWebhookEntries('https://example.com/hook')).toEqual([
+      { url: 'https://example.com/hook', token: null },
+    ]);
+  });
+
+  it('parses a url+token line', () => {
+    expect(parseWebhookEntries('https://example.com/hook mytoken123')).toEqual([
+      { url: 'https://example.com/hook', token: 'mytoken123' },
+    ]);
+  });
+
+  it('trailing space → token is null', () => {
+    expect(parseWebhookEntries('https://example.com/hook ')).toEqual([
+      { url: 'https://example.com/hook', token: null },
+    ]);
+  });
+
+  it('multiple spaces between url and token → token trimmed correctly', () => {
+    expect(parseWebhookEntries('https://example.com/hook   mytoken')).toEqual([
+      { url: 'https://example.com/hook', token: 'mytoken' },
+    ]);
+  });
+
+  it('parses multiple lines with mixed url-only and url+token', () => {
+    expect(
+      parseWebhookEntries('https://a.com/hook token_a\nhttps://b.com/hook')
+    ).toEqual([
+      { url: 'https://a.com/hook', token: 'token_a' },
+      { url: 'https://b.com/hook', token: null },
+    ]);
+  });
+
+  it('filters out blank lines', () => {
+    expect(
+      parseWebhookEntries('https://a.com/hook\n\nhttps://b.com/hook token_b')
+    ).toEqual([
+      { url: 'https://a.com/hook', token: null },
+      { url: 'https://b.com/hook', token: 'token_b' },
+    ]);
+  });
+
+  it('splits on commas (url-only entries)', () => {
+    expect(parseWebhookEntries('https://a.com/,https://b.com/')).toEqual([
+      { url: 'https://a.com/', token: null },
+      { url: 'https://b.com/', token: null },
+    ]);
+  });
+});
+
+// ── getWebhookEntries ─────────────────────────────────────────────────────────
+
+describe('getWebhookEntries', () => {
+  it('returns entries from event-specific field', () => {
+    const ctx = {
+      settings: { webhooksOnIssueCreated: 'https://a.com hook_a', webhooksOnAllEvents: '' },
+    };
+    expect(getWebhookEntries(ctx, 'webhooksOnIssueCreated')).toEqual([
+      { url: 'https://a.com', token: 'hook_a' },
+    ]);
+  });
+
+  it('combines event-specific and all-events entries', () => {
+    const ctx = {
+      settings: {
+        webhooksOnIssueCreated: 'https://a.com token_a',
+        webhooksOnAllEvents: 'https://b.com token_b',
+      },
+    };
+    expect(getWebhookEntries(ctx, 'webhooksOnIssueCreated')).toEqual([
+      { url: 'https://a.com', token: 'token_a' },
+      { url: 'https://b.com', token: 'token_b' },
+    ]);
+  });
+
+  it('deduplicates: event-specific version wins when same URL appears in both', () => {
+    const ctx = {
+      settings: {
+        webhooksOnIssueCreated: 'https://a.com token_specific',
+        webhooksOnAllEvents: 'https://a.com',
+      },
+    };
+    expect(getWebhookEntries(ctx, 'webhooksOnIssueCreated')).toEqual([
+      { url: 'https://a.com', token: 'token_specific' },
+    ]);
+  });
+
+  it('deduplicates: event-specific no-token wins over all-events token when event-specific is listed first', () => {
+    const ctx = {
+      settings: {
+        webhooksOnIssueCreated: 'https://a.com',
+        webhooksOnAllEvents: 'https://a.com token_all',
+      },
+    };
+    expect(getWebhookEntries(ctx, 'webhooksOnIssueCreated')).toEqual([
+      { url: 'https://a.com', token: null },
+    ]);
+  });
+
+  it('returns [] when both fields are empty', () => {
+    const ctx = {
+      settings: { webhooksOnIssueCreated: '', webhooksOnAllEvents: '' },
+    };
+    expect(getWebhookEntries(ctx, 'webhooksOnIssueCreated')).toEqual([]);
+  });
+
+  it('returns all-events entries when event-specific field is absent', () => {
+    const ctx = {
+      settings: { webhooksOnAllEvents: 'https://b.com token_b' },
+    };
+    expect(getWebhookEntries(ctx, 'webhooksOnIssueCreated')).toEqual([
+      { url: 'https://b.com', token: 'token_b' },
     ]);
   });
 });
@@ -111,5 +255,225 @@ describe('sendWebhook URL validation', () => {
       );
       expect(result).not.toBeNull();
     });
+  });
+});
+
+// ── sendWebhooks ──────────────────────────────────────────────────────────────
+
+describe('sendWebhooks', () => {
+  const PAYLOAD = { event: 'test' };
+
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  it('sends to an entry with an inline token when webhookToken is absent', () => {
+    const ctx = {
+      settings: {
+        webhooksOnIssueCreated: 'https://example.com/hook inline_token',
+        webhooksOnAllEvents: '',
+      },
+    };
+    sendWebhooks(ctx, 'webhooksOnIssueCreated', PAYLOAD, 'issueCreated');
+    expect(console.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('No token configured')
+    );
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining('Sending webhooks to 1')
+    );
+  });
+
+  it('skips an entry and warns when effectiveToken is null (no inline token, no webhookToken)', () => {
+    const ctx = {
+      settings: {
+        webhooksOnIssueCreated: 'https://example.com/hook',
+        webhooksOnAllEvents: '',
+      },
+    };
+    sendWebhooks(ctx, 'webhooksOnIssueCreated', PAYLOAD, 'issueCreated');
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('No token configured for https://example.com/hook')
+    );
+  });
+
+  it('uses inline token and does NOT count that entry as a fallback user', () => {
+    // Two URLs: A has inline token, B uses fallback. Fallback-user count = 1 → no deprecation warning.
+    const ctx = {
+      settings: {
+        webhooksOnIssueCreated: 'https://a.com/hook inline_token\nhttps://b.com/hook',
+        webhooksOnAllEvents: '',
+        webhookToken: 'global_token',
+        headerName: 'X-Token',
+      },
+    };
+    sendWebhooks(ctx, 'webhooksOnIssueCreated', PAYLOAD, 'issueCreated');
+    expect(console.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('sharing the global webhookToken fallback')
+    );
+  });
+
+  it('emits deprecation warning when fallback-user count > 1', () => {
+    const ctx = {
+      settings: {
+        webhooksOnIssueCreated: 'https://a.com/hook\nhttps://b.com/hook',
+        webhooksOnAllEvents: '',
+        webhookToken: 'global_token',
+        headerName: 'X-Token',
+      },
+    };
+    sendWebhooks(ctx, 'webhooksOnIssueCreated', PAYLOAD, 'issueCreated');
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('sharing the global webhookToken fallback')
+    );
+  });
+
+  it('does NOT emit deprecation warning when exactly one entry uses the fallback', () => {
+    const ctx = {
+      settings: {
+        webhooksOnIssueCreated: 'https://a.com/hook',
+        webhooksOnAllEvents: '',
+        webhookToken: 'global_token',
+        headerName: 'X-Token',
+      },
+    };
+    sendWebhooks(ctx, 'webhooksOnIssueCreated', PAYLOAD, 'issueCreated');
+    expect(console.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('sharing the global webhookToken fallback')
+    );
+  });
+
+  it('uses default header name (X-YouTrack-Token) when headerName is absent from settings', () => {
+    const ctx = {
+      settings: {
+        webhooksOnIssueCreated: 'https://example.com/hook inline_token',
+        webhooksOnAllEvents: '',
+      },
+    };
+    // Should not skip or throw — headerName fallback to 'X-YouTrack-Token'
+    sendWebhooks(ctx, 'webhooksOnIssueCreated', PAYLOAD, 'issueCreated');
+    expect(console.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('No token configured')
+    );
+  });
+
+  it('logs a message when no URLs are configured', () => {
+    const ctx = {
+      settings: {
+        webhooksOnIssueCreated: '',
+        webhooksOnAllEvents: '',
+        webhookToken: 'global_token',
+      },
+    };
+    sendWebhooks(ctx, 'webhooksOnIssueCreated', PAYLOAD, 'issueCreated');
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining('No webhook URLs configured')
+    );
+  });
+});
+
+// ── sendWebhooks — token dispatch verification (Connection spy) ───────────────
+
+describe('sendWebhooks token dispatch', () => {
+  const PAYLOAD = { event: 'test' };
+  let addHeaderSpy;
+  let capturedCalls; // {url, name, value}[]
+
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    capturedCalls = [];
+    addHeaderSpy = vi
+      .spyOn(httpMock.Connection.prototype, 'addHeader')
+      .mockImplementation(function (name, value) {
+        capturedCalls.push({ url: this.url, name, value });
+      });
+  });
+
+  afterEach(() => {
+    addHeaderSpy.mockRestore();
+  });
+
+  it('inline token wins over global webhookToken when both are present', () => {
+    const ctx = {
+      settings: {
+        webhooksOnIssueCreated: 'https://example.com/hook inline_token',
+        webhooksOnAllEvents: '',
+        webhookToken: 'global_token',
+        headerName: 'X-Test-Token',
+      },
+    };
+    sendWebhooks(ctx, 'webhooksOnIssueCreated', PAYLOAD, 'issueCreated');
+    const authCalls = capturedCalls.filter(
+      c => c.url === 'https://example.com/hook' && c.name === 'X-Test-Token'
+    );
+    expect(authCalls).toHaveLength(1);
+    expect(authCalls[0].value).toBe('inline_token');
+  });
+
+  it('each URL receives its own distinct inline token', () => {
+    const ctx = {
+      settings: {
+        webhooksOnIssueCreated: 'https://a.com/hook token_a\nhttps://b.com/hook token_b',
+        webhooksOnAllEvents: '',
+        headerName: 'X-Test-Token',
+      },
+    };
+    sendWebhooks(ctx, 'webhooksOnIssueCreated', PAYLOAD, 'issueCreated');
+    const forA = capturedCalls.find(
+      c => c.url === 'https://a.com/hook' && c.name === 'X-Test-Token'
+    );
+    const forB = capturedCalls.find(
+      c => c.url === 'https://b.com/hook' && c.name === 'X-Test-Token'
+    );
+    expect(forA?.value).toBe('token_a');
+    expect(forB?.value).toBe('token_b');
+  });
+
+  it('global token is sent when entry has no inline token', () => {
+    const ctx = {
+      settings: {
+        webhooksOnIssueCreated: 'https://example.com/hook',
+        webhooksOnAllEvents: '',
+        webhookToken: 'global_token',
+        headerName: 'X-Test-Token',
+      },
+    };
+    sendWebhooks(ctx, 'webhooksOnIssueCreated', PAYLOAD, 'issueCreated');
+    const authCalls = capturedCalls.filter(
+      c => c.url === 'https://example.com/hook' && c.name === 'X-Test-Token'
+    );
+    expect(authCalls).toHaveLength(1);
+    expect(authCalls[0].value).toBe('global_token');
+  });
+
+  it('no HTTP call made for a skipped entry (null effective token)', () => {
+    const ctx = {
+      settings: {
+        webhooksOnIssueCreated: 'https://example.com/hook',
+        webhooksOnAllEvents: '',
+        // no webhookToken, no inline token
+      },
+    };
+    sendWebhooks(ctx, 'webhooksOnIssueCreated', PAYLOAD, 'issueCreated');
+    const authCalls = capturedCalls.filter(c => c.url === 'https://example.com/hook');
+    expect(authCalls).toHaveLength(0);
+  });
+
+  it('warns when effective token contains whitespace', () => {
+    const ctx = {
+      settings: {
+        webhooksOnIssueCreated: 'https://example.com/hook tok en with spaces',
+        webhooksOnAllEvents: '',
+        headerName: 'X-Test-Token',
+      },
+    };
+    sendWebhooks(ctx, 'webhooksOnIssueCreated', PAYLOAD, 'issueCreated');
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('contains whitespace')
+    );
   });
 });

--- a/packages/webhook-triggers-app/src/workflows/__tests__/workflow-http.test.js
+++ b/packages/webhook-triggers-app/src/workflows/__tests__/workflow-http.test.js
@@ -476,4 +476,33 @@ describe('sendWebhooks token dispatch', () => {
       expect.stringContaining('contains whitespace')
     );
   });
+
+  it('warns when inline token is shorter than 32 characters', () => {
+    const ctx = {
+      settings: {
+        webhooksOnIssueCreated: 'https://example.com/hook short',
+        webhooksOnAllEvents: '',
+        headerName: 'X-Test-Token',
+      },
+    };
+    sendWebhooks(ctx, 'webhooksOnIssueCreated', PAYLOAD, 'issueCreated');
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('shorter than 32 characters')
+    );
+  });
+
+  it('does NOT warn about token length for the fallback global token (schema enforces it)', () => {
+    const ctx = {
+      settings: {
+        webhooksOnIssueCreated: 'https://example.com/hook',
+        webhooksOnAllEvents: '',
+        webhookToken: 'short',
+        headerName: 'X-Test-Token',
+      },
+    };
+    sendWebhooks(ctx, 'webhooksOnIssueCreated', PAYLOAD, 'issueCreated');
+    expect(console.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('shorter than 32 characters')
+    );
+  });
 });

--- a/packages/webhook-triggers-app/src/workflows/workflow-core.js
+++ b/packages/webhook-triggers-app/src/workflows/workflow-core.js
@@ -12,7 +12,9 @@ const httpModule = require('./workflow-http');
 const guardsModule = require('./workflow-guards');
 const utilsModule = require('./workflow-utils');
 
+exports.parseWebhookEntries = httpModule.parseWebhookEntries;
 exports.parseWebhookUrls = httpModule.parseWebhookUrls;
+exports.getWebhookEntries = httpModule.getWebhookEntries;
 exports.getWebhookUrls = httpModule.getWebhookUrls;
 exports.sendWebhook = httpModule.sendWebhook;
 exports.sendWebhooks = httpModule.sendWebhooks;

--- a/packages/webhook-triggers-app/src/workflows/workflow-http.js
+++ b/packages/webhook-triggers-app/src/workflows/workflow-http.js
@@ -60,24 +60,23 @@ function getWebhookEntries(ctx, settingsKey) {
   var eventEntries = parseWebhookEntries(ctx.settings[settingsKey] || '');
   var allEventsEntries = parseWebhookEntries(ctx.settings.webhooksOnAllEvents || '');
 
-  var urlSet = Object.create(null);
-  var allEntries = [];
+  var tokenByUrl = Object.create(null);
+  var order = [];
 
-  eventEntries.forEach(function(entry) {
-    if (entry.url && !urlSet[entry.url]) {
-      allEntries.push(entry);
-      urlSet[entry.url] = true;
+  function addEntry(entry) {
+    if (!entry.url) { return; }
+    if (!(entry.url in tokenByUrl)) {
+      order.push(entry.url);
+      tokenByUrl[entry.url] = entry.token;
+    } else if (tokenByUrl[entry.url] == null && entry.token != null) {
+      tokenByUrl[entry.url] = entry.token;
     }
-  });
+  }
 
-  allEventsEntries.forEach(function(entry) {
-    if (entry.url && !urlSet[entry.url]) {
-      allEntries.push(entry);
-      urlSet[entry.url] = true;
-    }
-  });
+  eventEntries.forEach(addEntry);
+  allEventsEntries.forEach(addEntry);
 
-  return allEntries;
+  return order.map(function(url) { return { url: url, token: tokenByUrl[url] }; });
 }
 
 /**

--- a/packages/webhook-triggers-app/src/workflows/workflow-http.js
+++ b/packages/webhook-triggers-app/src/workflows/workflow-http.js
@@ -11,6 +11,11 @@ const security = require('./workflow-security');
 const WEBHOOK_TIMEOUT_MS = 5000;
 
 /**
+ * Minimum recommended token length (mirrors the schema minLength on webhookToken)
+ */
+const MIN_TOKEN_LENGTH = 32;
+
+/**
  * Parse comma or newline separated webhook entries from settings.
  * Each line may be "url" or "url token" (split on first whitespace).
  * @param {string} webhooksStr
@@ -181,6 +186,9 @@ function sendWebhooks(ctx, settingsKey, payload, eventName) {
     }
     if (/\s/.test(effectiveToken)) {
       console.warn('[webhooks] Token for ' + entry.url + ' contains whitespace — HTTP header values with spaces may be rejected by some services.');
+    }
+    if (entry.token != null && entry.token.length < MIN_TOKEN_LENGTH) {
+      console.warn('[webhooks] Inline token for ' + entry.url + ' is shorter than ' + MIN_TOKEN_LENGTH + ' characters — short tokens are easier to brute-force. Consider using a longer token.');
     }
     if (entry.token == null) {
       fallbackCount++;

--- a/packages/webhook-triggers-app/src/workflows/workflow-http.js
+++ b/packages/webhook-triggers-app/src/workflows/workflow-http.js
@@ -11,21 +11,68 @@ const security = require('./workflow-security');
 const WEBHOOK_TIMEOUT_MS = 5000;
 
 /**
+ * Parse comma or newline separated webhook entries from settings.
+ * Each line may be "url" or "url token" (split on first whitespace).
+ * @param {string} webhooksStr
+ * @returns {Array<{url: string, token: string|null}>}
+ */
+function parseWebhookEntries(webhooksStr) {
+  if (!webhooksStr || typeof webhooksStr !== 'string') {
+    return [];
+  }
+  return webhooksStr.split(/[,\n]/)
+    .map(function(segment) {
+      var trimmed = segment.trim();
+      if (!trimmed) {return null;}
+      var spaceIdx = trimmed.search(/\s/);
+      if (spaceIdx === -1) {
+        return { url: trimmed, token: null };
+      }
+      var url = trimmed.slice(0, spaceIdx);
+      var token = trimmed.slice(spaceIdx).trim();
+      return { url: url, token: token || null };
+    })
+    .filter(function(e) { return e !== null; });
+}
+
+/**
  * Parse comma or newline separated webhook URLs from settings
  * @param {string} webhooksStr - Comma or newline separated webhook URLs
  * @returns {Array<string>} Array of trimmed, non-empty URLs
  */
 function parseWebhookUrls(webhooksStr) {
-  if (!webhooksStr || typeof webhooksStr !== 'string') {
-    return [];
-  }
-  return webhooksStr.split(/[,\n]/)  // Split by comma OR newline
-    .map(function (s) {
-      return s.trim();
-    })
-    .filter(function (s) {
-      return s.length > 0;
-    });
+  return parseWebhookEntries(webhooksStr).map(function(e) { return e.url; });
+}
+
+/**
+ * Gets all webhook entries for an event, combining event-specific and "All Events" entries.
+ * Deduplicates by URL (first-wins; event-specific is processed first).
+ * @param {Object} ctx - The workflow context with settings
+ * @param {string} settingsKey - The key in ctx.settings to get webhook entries from
+ * @returns {Array<{url: string, token: string|null}>}
+ */
+function getWebhookEntries(ctx, settingsKey) {
+  var eventEntries = parseWebhookEntries(ctx.settings[settingsKey] || '');
+  var allEventsEntries = parseWebhookEntries(ctx.settings.webhooksOnAllEvents || '');
+
+  var urlSet = Object.create(null);
+  var allEntries = [];
+
+  eventEntries.forEach(function(entry) {
+    if (entry.url && !urlSet[entry.url]) {
+      allEntries.push(entry);
+      urlSet[entry.url] = true;
+    }
+  });
+
+  allEventsEntries.forEach(function(entry) {
+    if (entry.url && !urlSet[entry.url]) {
+      allEntries.push(entry);
+      urlSet[entry.url] = true;
+    }
+  });
+
+  return allEntries;
 }
 
 /**
@@ -36,33 +83,7 @@ function parseWebhookUrls(webhooksStr) {
  * @returns {Array<string>} Deduplicated array of webhook URLs
  */
 function getWebhookUrls(ctx, settingsKey) {
-  // Parse event-specific webhooks
-  const webhooksStr = ctx.settings[settingsKey] || '';
-  const eventUrls = parseWebhookUrls(webhooksStr);
-
-  // Parse "All Events" webhooks
-  const allEventsWebhooksStr = ctx.settings.webhooksOnAllEvents || '';
-  const allEventsUrls = parseWebhookUrls(allEventsWebhooksStr);
-
-  // Combine and deduplicate
-  const urlSet = {};
-  const allUrls = [];
-
-  eventUrls.forEach(function (url) {
-    if (url && !urlSet[url]) {
-      allUrls.push(url);
-      urlSet[url] = true;
-    }
-  });
-
-  allEventsUrls.forEach(function (url) {
-    if (url && !urlSet[url]) {
-      allUrls.push(url);
-      urlSet[url] = true;
-    }
-  });
-
-  return allUrls;
+  return getWebhookEntries(ctx, settingsKey).map(function(e) { return e.url; });
 }
 
 /**
@@ -75,7 +96,7 @@ function logWebhookResponse(postResult, url) {
     console.warn('[webhooks] Webhook request to ' + url + ' completed but returned no status code (likely timeout after ' + WEBHOOK_TIMEOUT_MS + 'ms)');
     return;
   }
-  
+
   console.log('[webhooks] Webhook sent successfully to ' + url);
   if (postResult) {
     console.log('[webhooks] Response code: ' + (postResult.code || 'unknown'));
@@ -140,33 +161,45 @@ function sendWebhook(url, payload, eventName, token, headerName) {
  * @param {string} eventName - Name of the event for logging
  */
 function sendWebhooks(ctx, settingsKey, payload, eventName) {
-  const token = ctx.settings.webhookToken || null;
-  if (!token) {
-    console.warn('[webhooks] No webhook token configured - webhooks disabled for ' + eventName);
-    return;
-  }
+  var headerName = ctx.settings.headerName || 'X-YouTrack-Token';
+  var globalToken = ctx.settings.webhookToken || null;
 
-  const headerName = ctx.settings.headerName || null;
-  if (!headerName) {
-    console.warn('[webhooks] No header name configured - webhooks disabled for ' + eventName);
-    return;
-  }
-
-  // Get all URLs (event-specific + "All Events", deduplicated)
-  const allUrls = getWebhookUrls(ctx, settingsKey);
-
-  if (allUrls.length === 0) {
+  var allEntries = getWebhookEntries(ctx, settingsKey);
+  if (allEntries.length === 0) {
     console.log('[webhooks] No webhook URLs configured for ' + eventName);
     return;
   }
 
-  console.log('[webhooks] Sending webhooks to ' + allUrls.length + ' URL(s)');
-  allUrls.forEach(function (url) {
-    sendWebhook(url, payload, eventName, token, headerName);
+  console.log('[webhooks] Sending webhooks to ' + allEntries.length + ' URL(s)');
+
+  var fallbackCount = 0;
+  allEntries.forEach(function(entry) {
+    var effectiveToken = entry.token != null ? entry.token : globalToken;
+    if (effectiveToken == null) {
+      console.warn('[webhooks] No token configured for ' + entry.url + ' — skipping');
+      return;
+    }
+    if (/\s/.test(effectiveToken)) {
+      console.warn('[webhooks] Token for ' + entry.url + ' contains whitespace — HTTP header values with spaces may be rejected by some services.');
+    }
+    if (entry.token == null) {
+      fallbackCount++;
+    }
+    sendWebhook(entry.url, payload, eventName, effectiveToken, headerName);
   });
+
+  if (fallbackCount > 1) {
+    console.warn(
+      '[webhooks] ' + fallbackCount + ' webhook URLs are sharing the global webhookToken fallback. ' +
+      'A token compromise at any one endpoint exposes all others sharing the same token. ' +
+      'Add a per-line inline token to each URL: https://example.com mytoken'
+    );
+  }
 }
 
+exports.parseWebhookEntries = parseWebhookEntries;
 exports.parseWebhookUrls = parseWebhookUrls;
+exports.getWebhookEntries = getWebhookEntries;
 exports.getWebhookUrls = getWebhookUrls;
 exports.sendWebhook = sendWebhook;
 exports.sendWebhooks = sendWebhooks;


### PR DESCRIPTION
Each webhook URL can now carry its own independent secret using an inline format in the existing textarea fields:

  https://n8n.example.com/webhook  token_a
  https://slack.com/services/xxxxxxx   token_b

Previously a single shared webhookToken was sent to every endpoint. A compromise at any one recipient exposed all others.

Changes:
- New url+token line format: split on first whitespace, token is optional
- parseWebhookEntries() is the new core parse primitive; parseWebhookUrls delegates to it (backward-compatible wrapper)
- getWebhookEntries() is the new core combine/dedup function; getWebhookUrls delegates to it (backward-compatible wrapper)
- sendWebhooks() resolves token per-entry: inline token takes priority, falls back to global webhookToken, skips the entry if neither is set
- Runtime deprecation warning fires when 2+ URLs share the global fallback
- webhookToken made optional in settings.json (existing deployments continue to work unchanged via fallback)
- All textarea descriptions updated with inline-token format docs