### PR TITLE
JT-95741 fix(issue-dashboard-widgets): hash entry bundle filenames to bust browser cache

### DIFF
--- a/packages/issue-dashboard-widgets/webpack.config.js
+++ b/packages/issue-dashboard-widgets/webpack.config.js
@@ -49,7 +49,7 @@ const webpackConfig = () => ({
   },
   output: {
     path: resolve(__dirname, pkgConfig.dist),
-    filename: pathData => `widgets/${pathData.chunk.name}/[name].js`,
+    filename: pathData => `widgets/${pathData.chunk.name}/[name].[contenthash:8].js`,
     chunkFilename: 'widgets/shared/[name].[chunkhash:4].js',
     devtoolModuleFilenameTemplate: '[absolute-resource-path]'
   },


### PR DESCRIPTION
## Summary
- Entry bundles (`youtrack-issues-list.js`, `due-dates-calendar.js`, …) were emitted at stable, unhashed URLs while only the vendor chunks carried `[chunkhash:4]`. When the marketplace updated the app, the new `index.html` (served with `max-age=0`) pointed at fresh hashed vendor chunks, but the browser kept serving the old main bundle from disk cache. The cached old bundle then required modules that no longer exist in the new vendor chunks and crashed at init with `Uncaught TypeError: i(...) is not a function`. The widget never made any API call — observed in the field on `youtrack.ariva-services.de` (dashboard 527-4, 9 Issue List widgets, all blank).
- Adds `[contenthash:8]` to the entry filename in `packages/issue-dashboard-widgets/webpack.config.js`. `HtmlWebpackPlugin` rewrites the `<script src=…>` tags automatically, so `index.html` and `widget-settings.json` paths (which the marketplace `manifest.json` references) stay stable. When the bundle content changes, the URL changes, and stale main-bundle/fresh-vendor-chunk pairs become impossible.
- Also explains why this only affects long-time users: fresh installs never had the old cached bundle.

## Test plan
- [ ] `npm run build` in `packages/issue-dashboard-widgets/` succeeds.
- [ ] Output filenames now include an 8-char hash (e.g. `youtrack-issues-list.d55a7788.js`, `due-dates-calendar.add81afc.js`).
- [ ] Each generated `widgets/<name>/index.html` references the hashed filename in its `<script>` tag.
- [ ] Vendor chunks under `widgets/shared/` keep their existing 4-char `chunkhash` (unchanged).
- [ ] Smoke test: install the new build, confirm the four widgets (Issue List, Distribution Report, Calendar, Activity Feed) load and fetch data from a dashboard.
- [ ] Repro check: load the broken pre-fix bundle in a browser, hard-refresh — error reproduces; load this build — error gone.