### PR TITLE
JT-95488 Move "Webhooks Trigger" App to async functions

### DIFF
--- a/packages/webhook-triggers-app/manifest.json
+++ b/packages/webhook-triggers-app/manifest.json
@@ -3,7 +3,7 @@
   "title": "Webhook Triggers",
   "description": "The Webhook Triggers app lets you send webhooks to external systems when events occur in YouTrack, for example, when issues, comments, work items, or attachments are created, updated, or deleted. You can configure multiple webhook URLs for each event in the project settings.",
   "version": "1.0.5",
-  "minYouTrackVersion": "2024.3.0",
+  "minYouTrackVersion": "2026.2.0",
   "$schema": "https://json.schemastore.org/youtrack-app.json",
   "vendor": {
     "name": "JetBrains",

--- a/packages/webhook-triggers-app/src/workflows/__tests__/helpers/ctx.js
+++ b/packages/webhook-triggers-app/src/workflows/__tests__/helpers/ctx.js
@@ -1,0 +1,42 @@
+/**
+ * Test helper: a minimal stand-in for the async-function ctx object.
+ *
+ * - `settings` is the workflow settings map.
+ * - `store(key, value)` and `load(key)` back into an internal Map.
+ * - `invokeAsync(name, delay)` records the scheduled call. Tests can
+ *   invoke the recorded async function by reading `invocations` and
+ *   calling `run(name)`.
+ * - `response` is null by default; tests assign it before re-entering
+ *   an async handler to simulate a webhook response.
+ */
+export function createCtx({ settings = {}, asyncFunctions = {} } = {}) {
+  const storeMap = new Map();
+  const invocations = [];
+
+  const ctx = {
+    settings,
+    response: null,
+    store(key, value) {
+      storeMap.set(key, value);
+    },
+    load(key) {
+      return storeMap.has(key) ? storeMap.get(key) : null;
+    },
+    invokeAsync(name, delay) {
+      invocations.push({ name, delay });
+    },
+  };
+
+  ctx._storeMap = storeMap;
+  ctx._invocations = invocations;
+  ctx._asyncFunctions = asyncFunctions;
+  ctx.run = function (name) {
+    const fn = asyncFunctions[name];
+    if (!fn) {
+      throw new Error('No async function: ' + name);
+    }
+    fn(ctx);
+  };
+
+  return ctx;
+}

--- a/packages/webhook-triggers-app/src/workflows/__tests__/mocks/youtrack-http.cjs
+++ b/packages/webhook-triggers-app/src/workflows/__tests__/mocks/youtrack-http.cjs
@@ -1,15 +1,48 @@
 /**
  * CJS stub for @jetbrains/youtrack-scripting-api/http used in tests.
  * Loaded via Module._resolveFilename patch in setup.js.
+ *
+ * Each Connection instance records all calls. The `instances` array is
+ * attached to globalThis so that this stub (loaded as CJS by Node) and an
+ * ESM-side mirror loaded by Vitest share the same recording — Vitest's
+ * resolver does not always reuse Node's CJS require cache, so a plain
+ * module-level array would drift between the two loaders.
  */
 
+if (!globalThis.__youtrackHttpStub) {
+  globalThis.__youtrackHttpStub = { instances: [] };
+}
+const state = globalThis.__youtrackHttpStub;
+
 class Connection {
-  constructor(url) {
+  constructor(url, sslKeyName, timeout) {
     this.url = url;
+    this.sslKeyName = sslKeyName;
+    this.timeout = timeout;
     this.headers = {};
+    this.calls = [];
+    state.instances.push(this);
   }
-  addHeader(name, value) { this.headers[name] = value; }
-  postSync() { return { code: 200, response: '' }; }
+  addHeader(name, value) {
+    this.headers[name] = value;
+  }
+  postSync(uri, queryParams, payload) {
+    this.calls.push({ method: 'postSync', uri, queryParams, payload });
+    return { code: 200, response: '' };
+  }
+  postAsync(uri, queryParams, payload, handlerName) {
+    this.calls.push({ method: 'postAsync', uri, queryParams, payload, handlerName });
+  }
 }
 
-module.exports = { Connection };
+function reset() {
+  state.instances.length = 0;
+}
+
+module.exports = {
+  Connection,
+  get instances() {
+    return state.instances;
+  },
+  reset,
+};

--- a/packages/webhook-triggers-app/src/workflows/__tests__/mocks/youtrack-http.js
+++ b/packages/webhook-triggers-app/src/workflows/__tests__/mocks/youtrack-http.js
@@ -1,18 +1,31 @@
 /**
- * Minimal stub for @jetbrains/youtrack-scripting-api/http used in tests.
- * Tests that need to control Connection behaviour should vi.mock this module.
+ * ESM mirror of the CJS stub for @jetbrains/youtrack-scripting-api/http.
+ * Tests that need to inspect Connection behaviour should import from the
+ * .cjs file (the one wired into Module._resolveFilename in setup.js) — this
+ * ESM copy exists so the directory can be browsed without confusion.
  */
 
-export class Connection {
-  constructor() {
-    this.headers = {};
-  }
+const instances = [];
 
+export class Connection {
+  constructor(url, sslKeyName, timeout) {
+    this.url = url;
+    this.sslKeyName = sslKeyName;
+    this.timeout = timeout;
+    this.headers = {};
+    this.calls = [];
+    instances.push(this);
+  }
   addHeader(name, value) {
     this.headers[name] = value;
   }
-
-  postSync() {
+  postSync(uri, queryParams, payload) {
+    this.calls.push({ method: 'postSync', uri, queryParams, payload });
     return { code: 200, response: '' };
   }
+  postAsync(uri, queryParams, payload, handlerName) {
+    this.calls.push({ method: 'postAsync', uri, queryParams, payload, handlerName });
+  }
 }
+
+export { instances };

--- a/packages/webhook-triggers-app/src/workflows/__tests__/workflow-http.test.js
+++ b/packages/webhook-triggers-app/src/workflows/__tests__/workflow-http.test.js
@@ -1,7 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 // @jetbrains/youtrack-scripting-api/http is stubbed by setup.js via
 // Module._resolveFilename so workflow-http.js loads without YouTrack runtime.
-import { parseWebhookUrls, sendWebhook } from '../workflow-http.js';
+import {
+  parseWebhookUrls,
+  sendWebhooks,
+  logAndPostNext,
+  asyncFunctions,
+  MAX_WEBHOOK_URLS_PER_EVENT,
+} from '../workflow-http.js';
+import { createCtx } from './helpers/ctx.js';
+// Reach into the CJS stub to inspect Connection instances.
+import httpStub from './mocks/youtrack-http.cjs';
+
+const { instances: httpInstances, reset: resetHttp } = httpStub;
 
 // ── parseWebhookUrls ──────────────────────────────────────────────────────────
 
@@ -57,59 +68,423 @@ describe('parseWebhookUrls', () => {
   });
 });
 
-// ── sendWebhook — SSRF validation ─────────────────────────────────────────────
+// ── sendWebhooks: sync action dispatches URL #1 directly via postAsync ───────
 
-describe('sendWebhook URL validation', () => {
+describe('sendWebhooks scheduling', () => {
   const TOKEN = 'test-token';
   const HEADER = 'X-Token';
   const PAYLOAD = { event: 'test' };
 
   beforeEach(() => {
+    resetHttp();
     vi.spyOn(console, 'error').mockImplementation(() => {});
     vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
-  describe('blocked URLs', () => {
-    it.each([
-      ['10.x RFC-1918',        'http://10.0.0.1/'],
-      ['172.16.x RFC-1918',    'http://172.16.0.1/'],
-      ['172.31.x RFC-1918',    'http://172.31.255.255/'],
-      ['192.168.x RFC-1918',   'http://192.168.1.1/'],
-      ['169.254.x link-local', 'http://169.254.169.254/latest/meta-data/'],
-      ['file:// scheme',       'file:///etc/passwd'],
-      ['ftp:// scheme',        'ftp://example.com/'],
-    ])('returns null for %s (%s)', (_label, url) => {
-      const result = sendWebhook(url, PAYLOAD, 'test-event', TOKEN, HEADER);
-      expect(result).toBeNull();
-      expect(console.error).toHaveBeenCalledWith(
-        expect.stringContaining('[webhooks] Blocked webhook to')
-      );
+  it('dispatches URL #1 via postAsync with logAndPostNext as response handler', () => {
+    const ctx = createCtx({
+      settings: {
+        webhookToken: TOKEN,
+        headerName: HEADER,
+        webhooksOnIssueCreated: 'https://a.com/,https://b.com/',
+      },
+      asyncFunctions,
     });
+    sendWebhooks(ctx, 'webhooksOnIssueCreated', PAYLOAD, 'IssueCreated');
+
+    expect(httpInstances).toHaveLength(1);
+    const conn = httpInstances[0];
+    expect(conn.url).toBe('https://a.com/');
+    expect(conn.calls).toHaveLength(1);
+    expect(conn.calls[0].method).toBe('postAsync');
+    expect(conn.calls[0].handlerName).toBe('logAndPostNext');
+    expect(conn.calls[0].payload).toBe(JSON.stringify(PAYLOAD));
   });
 
-  describe('allowed URLs', () => {
-    it('sends the request for a valid public HTTPS URL', () => {
-      const result = sendWebhook(
-        'https://example.com/webhook', PAYLOAD, 'test-event', TOKEN, HEADER
-      );
-      expect(result).not.toBeNull();
-      expect(result.code).toBe(200);
+  it('stores remaining URL list, payload, and current URL for the async chain', () => {
+    const ctx = createCtx({
+      settings: {
+        webhookToken: TOKEN,
+        headerName: HEADER,
+        webhooksOnIssueCreated: 'https://a.com/,https://b.com/',
+      },
+      asyncFunctions,
+    });
+    sendWebhooks(ctx, 'webhooksOnIssueCreated', PAYLOAD, 'IssueCreated');
+
+    // URL #1 dispatched; URL #2 remains in store.
+    expect(JSON.parse(ctx._storeMap.get('webhookUrls'))).toEqual([
+      'https://b.com/',
+    ]);
+    expect(ctx._storeMap.get('webhookCurrentUrl')).toBe('https://a.com/');
+    expect(JSON.parse(ctx._storeMap.get('webhookPayload'))).toEqual(PAYLOAD);
+    expect(ctx._storeMap.get('webhookEvent')).toBe('IssueCreated');
+    // Token and headerName are intentionally NOT in ctx.store — they're
+    // read from ctx.settings on each hop to avoid SecretAttributeValue
+    // toString() coercion. See workflow-http.js comment above STORE_URLS.
+    expect(ctx._storeMap.has('webhookToken')).toBe(false);
+    expect(ctx._storeMap.has('webhookHeader')).toBe(false);
+  });
+
+  it('does not dispatch when no URLs are configured', () => {
+    const ctx = createCtx({
+      settings: { webhookToken: TOKEN, headerName: HEADER },
+      asyncFunctions,
+    });
+    sendWebhooks(ctx, 'webhooksOnIssueCreated', PAYLOAD, 'IssueCreated');
+    expect(httpInstances).toHaveLength(0);
+  });
+
+  it('does not dispatch when token is missing', () => {
+    const ctx = createCtx({
+      settings: {
+        headerName: HEADER,
+        webhooksOnIssueCreated: 'https://a.com/',
+      },
+      asyncFunctions,
+    });
+    sendWebhooks(ctx, 'webhooksOnIssueCreated', PAYLOAD, 'IssueCreated');
+    expect(httpInstances).toHaveLength(0);
+  });
+
+  it('does not dispatch when header name is missing', () => {
+    const ctx = createCtx({
+      settings: {
+        webhookToken: TOKEN,
+        webhooksOnIssueCreated: 'https://a.com/',
+      },
+      asyncFunctions,
+    });
+    sendWebhooks(ctx, 'webhooksOnIssueCreated', PAYLOAD, 'IssueCreated');
+    expect(httpInstances).toHaveLength(0);
+  });
+
+  it('caps URL list at MAX_WEBHOOK_URLS_PER_EVENT and warns', () => {
+    const urls = [];
+    for (let i = 0; i < MAX_WEBHOOK_URLS_PER_EVENT + 3; i++) {
+      urls.push('https://host' + i + '.example.com/');
+    }
+    const ctx = createCtx({
+      settings: {
+        webhookToken: TOKEN,
+        headerName: HEADER,
+        webhooksOnIssueCreated: urls.join(','),
+      },
+      asyncFunctions,
+    });
+    sendWebhooks(ctx, 'webhooksOnIssueCreated', PAYLOAD, 'IssueCreated');
+
+    // URL #1 dispatched, URLs #2..MAX remain in store, URLs beyond MAX dropped.
+    const stored = JSON.parse(ctx._storeMap.get('webhookUrls'));
+    expect(stored).toHaveLength(MAX_WEBHOOK_URLS_PER_EVENT - 1);
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('max is ' + MAX_WEBHOOK_URLS_PER_EVENT),
+    );
+  });
+
+  it('skips an invalid first URL synchronously and dispatches the next valid one (no async hop consumed)', () => {
+    const ctx = createCtx({
+      settings: {
+        webhookToken: TOKEN,
+        headerName: HEADER,
+        webhooksOnIssueCreated: 'http://10.0.0.1/,https://b.com/',
+      },
+      asyncFunctions,
+    });
+    sendWebhooks(ctx, 'webhooksOnIssueCreated', PAYLOAD, 'IssueCreated');
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('Blocked webhook to http://10.0.0.1/'),
+    );
+    expect(httpInstances).toHaveLength(1);
+    expect(httpInstances[0].url).toBe('https://b.com/');
+  });
+
+  it('returns silently if all URLs are invalid', () => {
+    const ctx = createCtx({
+      settings: {
+        webhookToken: TOKEN,
+        headerName: HEADER,
+        webhooksOnIssueCreated: 'http://10.0.0.1/,file:///etc/passwd',
+      },
+      asyncFunctions,
+    });
+    sendWebhooks(ctx, 'webhooksOnIssueCreated', PAYLOAD, 'IssueCreated');
+
+    expect(httpInstances).toHaveLength(0);
+  });
+});
+
+// ── logAndPostNext: response handler that logs + chains via direct postAsync ─
+
+describe('logAndPostNext', () => {
+  const TOKEN = 'test-token';
+  const HEADER = 'X-Token';
+  const PAYLOAD = { event: 'test' };
+
+  function seedCtx(remainingUrls, currentUrl = 'https://a.com/') {
+    const ctx = createCtx({
+      settings: { webhookToken: TOKEN, headerName: HEADER },
+      asyncFunctions,
+    });
+    ctx.store('webhookUrls', JSON.stringify(remainingUrls));
+    ctx.store('webhookCurrentUrl', currentUrl);
+    ctx.store('webhookPayload', JSON.stringify(PAYLOAD));
+    ctx.store('webhookEvent', 'IssueCreated');
+    return ctx;
+  }
+
+  beforeEach(() => {
+    resetHttp();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  it('logs the successful response and dispatches the next URL directly via postAsync', () => {
+    const ctx = seedCtx(['https://b.com/']);
+    ctx.response = { code: 200 };
+    logAndPostNext(ctx);
+
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining('Webhook sent successfully to https://a.com/'),
+    );
+    expect(httpInstances).toHaveLength(1);
+    expect(httpInstances[0].url).toBe('https://b.com/');
+    expect(httpInstances[0].calls[0].method).toBe('postAsync');
+    expect(httpInstances[0].calls[0].handlerName).toBe('logAndPostNext');
+  });
+
+  it('does not dispatch when the URL list is empty', () => {
+    const ctx = seedCtx([]);
+    ctx.response = { code: 200 };
+    logAndPostNext(ctx);
+    expect(httpInstances).toHaveLength(0);
+  });
+
+  it('logs an error when ctx.response.exception is present and still dispatches the next URL', () => {
+    const ctx = seedCtx(['https://b.com/']);
+    ctx.response = { exception: 'timeout' };
+    logAndPostNext(ctx);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('Webhook to https://a.com/ failed: timeout'),
+    );
+    expect(httpInstances).toHaveLength(1);
+    expect(httpInstances[0].url).toBe('https://b.com/');
+  });
+
+  it('warns on no-status-code response (likely timeout)', () => {
+    const ctx = seedCtx([]);
+    ctx.response = { code: undefined };
+    logAndPostNext(ctx);
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('completed but returned no status code'),
+    );
+  });
+
+  it('shifts the dispatched URL out of the stored list and records currentUrl', () => {
+    const ctx = seedCtx(['https://b.com/', 'https://c.com/']);
+    ctx.response = { code: 200 };
+    logAndPostNext(ctx);
+    expect(JSON.parse(ctx._storeMap.get('webhookUrls'))).toEqual([
+      'https://c.com/',
+    ]);
+    expect(ctx._storeMap.get('webhookCurrentUrl')).toBe('https://b.com/');
+  });
+
+  it('skips an invalid next URL synchronously and dispatches the one after (no async hop consumed)', () => {
+    const ctx = seedCtx(['http://10.0.0.1/', 'https://c.com/']);
+    ctx.response = { code: 200 };
+    logAndPostNext(ctx);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('Blocked webhook to http://10.0.0.1/'),
+    );
+    expect(httpInstances).toHaveLength(1);
+    expect(httpInstances[0].url).toBe('https://c.com/');
+  });
+
+  it.each([
+    ['10.x RFC-1918', 'http://10.0.0.1/'],
+    ['172.16.x RFC-1918', 'http://172.16.0.1/'],
+    ['172.31.x RFC-1918', 'http://172.31.255.255/'],
+    ['192.168.x RFC-1918', 'http://192.168.1.1/'],
+    ['169.254.x link-local', 'http://169.254.169.254/latest/meta-data/'],
+    ['file:// scheme', 'file:///etc/passwd'],
+    ['ftp:// scheme', 'ftp://example.com/'],
+  ])('blocks %s (%s) when it is the next URL', (_label, url) => {
+    const ctx = seedCtx([url]);
+    ctx.response = { code: 200 };
+    logAndPostNext(ctx);
+    expect(httpInstances).toHaveLength(0);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('[webhooks] Blocked webhook to'),
+    );
+  });
+
+  it('warns when an HTTP (non-HTTPS) URL is used but still dispatches it', () => {
+    const ctx = seedCtx(['http://example.com/webhook']);
+    ctx.response = { code: 200 };
+    logAndPostNext(ctx);
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('webhook URL uses HTTP (not HTTPS)'),
+    );
+    expect(httpInstances).toHaveLength(1);
+    expect(httpInstances[0].calls[0].method).toBe('postAsync');
+  });
+});
+
+// ── End-to-end chain progression ──────────────────────────────────────────────
+
+describe('chain progression (sendWebhooks + logAndPostNext)', () => {
+  const TOKEN = 'test-token';
+  const HEADER = 'X-Token';
+  const PAYLOAD = { event: 'test' };
+
+  beforeEach(() => {
+    resetHttp();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  it('walks a 3-URL chain end-to-end via direct postAsync chaining (1 hop per URL)', () => {
+    const urls = ['https://a.com/', 'https://b.com/', 'https://c.com/'];
+    const ctx = createCtx({
+      settings: {
+        webhookToken: TOKEN,
+        headerName: HEADER,
+        webhooksOnIssueCreated: urls.join(','),
+      },
+      asyncFunctions,
     });
 
-    it('sends the request for a valid public HTTP URL', () => {
-      const result = sendWebhook(
-        'http://example.com/webhook', PAYLOAD, 'test-event', TOKEN, HEADER
-      );
-      expect(result).not.toBeNull();
-      expect(result.code).toBe(200);
+    // sync action: dispatches URL #1 directly.
+    sendWebhooks(ctx, 'webhooksOnIssueCreated', PAYLOAD, 'IssueCreated');
+    expect(httpInstances).toHaveLength(1);
+    expect(httpInstances[0].url).toBe('https://a.com/');
+
+    // hop 1: logAndPostNext fires with URL #1 response, dispatches URL #2.
+    ctx.response = { code: 200 };
+    logAndPostNext(ctx);
+    expect(httpInstances).toHaveLength(2);
+    expect(httpInstances[1].url).toBe('https://b.com/');
+
+    // hop 2: logAndPostNext fires with URL #2 response, dispatches URL #3.
+    ctx.response = { code: 200 };
+    logAndPostNext(ctx);
+    expect(httpInstances).toHaveLength(3);
+    expect(httpInstances[2].url).toBe('https://c.com/');
+
+    // hop 3: logAndPostNext fires with URL #3 response, no more URLs → chain ends.
+    ctx.response = { code: 200 };
+    logAndPostNext(ctx);
+    expect(httpInstances).toHaveLength(3);
+  });
+});
+
+// ── Fail-closed guard when settings change mid-chain ─────────────────────────
+
+describe('settings-disappear-mid-chain guard', () => {
+  const TOKEN = 'test-token';
+  const HEADER = 'X-Token';
+  const PAYLOAD = { event: 'test' };
+
+  beforeEach(() => {
+    resetHttp();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  it('aborts the chain when the webhook token is cleared between hops', () => {
+    const ctx = createCtx({
+      settings: {
+        webhookToken: TOKEN,
+        headerName: HEADER,
+        webhooksOnIssueCreated: 'https://a.com/,https://b.com/',
+      },
+      asyncFunctions,
     });
 
-    it('trims whitespace around valid URLs before connecting', () => {
-      const result = sendWebhook(
-        '  https://example.com/webhook  ', PAYLOAD, 'test-event', TOKEN, HEADER
-      );
-      expect(result).not.toBeNull();
+    // Sync action dispatches URL #1 normally (token present).
+    sendWebhooks(ctx, 'webhooksOnIssueCreated', PAYLOAD, 'IssueCreated');
+    expect(httpInstances).toHaveLength(1);
+    expect(httpInstances[0].headers[HEADER]).toBe(TOKEN);
+
+    // Admin clears the token between hops.
+    ctx.settings.webhookToken = null;
+
+    // Hop 1 — response for URL #1 arrives, logAndPostNext would normally
+    // dispatch URL #2 but must abort instead of sending it unauthenticated.
+    ctx.response = { code: 200 };
+    logAndPostNext(ctx);
+
+    expect(httpInstances).toHaveLength(1);
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Webhook token or header was cleared during chain execution'),
+    );
+  });
+
+  it('aborts the chain when the header name is cleared between hops', () => {
+    const ctx = createCtx({
+      settings: {
+        webhookToken: TOKEN,
+        headerName: HEADER,
+        webhooksOnIssueCreated: 'https://a.com/,https://b.com/',
+      },
+      asyncFunctions,
     });
+
+    sendWebhooks(ctx, 'webhooksOnIssueCreated', PAYLOAD, 'IssueCreated');
+    expect(httpInstances).toHaveLength(1);
+
+    ctx.settings.headerName = null;
+
+    ctx.response = { code: 200 };
+    logAndPostNext(ctx);
+
+    expect(httpInstances).toHaveLength(1);
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Webhook token or header was cleared during chain execution'),
+    );
+  });
+
+  it.each([
+    ['empty-string token', { webhookToken: '', headerName: HEADER }],
+    ['empty-string header', { webhookToken: TOKEN, headerName: '' }],
+    ['both empty strings', { webhookToken: '', headerName: '' }],
+  ])('aborts the chain when settings become %s mid-chain', (_label, mutated) => {
+    const ctx = createCtx({
+      settings: {
+        webhookToken: TOKEN,
+        headerName: HEADER,
+        webhooksOnIssueCreated: 'https://a.com/,https://b.com/',
+      },
+      asyncFunctions,
+    });
+
+    sendWebhooks(ctx, 'webhooksOnIssueCreated', PAYLOAD, 'IssueCreated');
+    expect(httpInstances).toHaveLength(1);
+
+    Object.assign(ctx.settings, mutated);
+
+    ctx.response = { code: 200 };
+    logAndPostNext(ctx);
+
+    expect(httpInstances).toHaveLength(1);
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Webhook token or header was cleared during chain execution'),
+    );
+  });
+});
+
+// ── asyncFunctions export ─────────────────────────────────────────────────────
+
+describe('asyncFunctions export', () => {
+  it('exposes logAndPostNext', () => {
+    expect(typeof asyncFunctions.logAndPostNext).toBe('function');
+    expect(asyncFunctions.logAndPostNext).toBe(logAndPostNext);
   });
 });

--- a/packages/webhook-triggers-app/src/workflows/on-attachment-added.js
+++ b/packages/webhook-triggers-app/src/workflows/on-attachment-added.js
@@ -59,6 +59,8 @@ exports.rule = {
         core.sendWebhooks(ctx, EVENTS.ATTACHMENT_ADDED.key, payload, EVENTS.ATTACHMENT_ADDED.name);
     },
 
+    asyncFunctions: core.asyncFunctions,
+
     requirements: {}
 };
 

--- a/packages/webhook-triggers-app/src/workflows/on-attachment-deleted.js
+++ b/packages/webhook-triggers-app/src/workflows/on-attachment-deleted.js
@@ -52,5 +52,7 @@ exports.rule = {
         core.sendWebhooks(ctx, EVENTS.ATTACHMENT_DELETED.key, payload, EVENTS.ATTACHMENT_DELETED.name);
     },
 
+    asyncFunctions: core.asyncFunctions,
+
     requirements: {}
 };

--- a/packages/webhook-triggers-app/src/workflows/on-comment-added.js
+++ b/packages/webhook-triggers-app/src/workflows/on-comment-added.js
@@ -51,5 +51,7 @@ exports.rule = {
         core.sendWebhooks(ctx, EVENTS.COMMENT_ADDED.key, payload, EVENTS.COMMENT_ADDED.name);
     },
 
+    asyncFunctions: core.asyncFunctions,
+
     requirements: {}
 };

--- a/packages/webhook-triggers-app/src/workflows/on-comment-deleted.js
+++ b/packages/webhook-triggers-app/src/workflows/on-comment-deleted.js
@@ -50,5 +50,7 @@ exports.rule = {
         core.sendWebhooks(ctx, EVENTS.COMMENT_DELETED.key, payload, EVENTS.COMMENT_DELETED.name);
     },
 
+    asyncFunctions: core.asyncFunctions,
+
     requirements: {}
 };

--- a/packages/webhook-triggers-app/src/workflows/on-comment-updated.js
+++ b/packages/webhook-triggers-app/src/workflows/on-comment-updated.js
@@ -56,6 +56,8 @@ exports.rule = {
         core.sendWebhooks(ctx, EVENTS.COMMENT_UPDATED.key, payload, EVENTS.COMMENT_UPDATED.name);
     },
 
+    asyncFunctions: core.asyncFunctions,
+
     requirements: {}
 };
 

--- a/packages/webhook-triggers-app/src/workflows/on-issue-created.js
+++ b/packages/webhook-triggers-app/src/workflows/on-issue-created.js
@@ -45,6 +45,8 @@ exports.rule = {
         core.sendWebhooks(ctx, EVENTS.ISSUE_CREATED.key, payload, EVENTS.ISSUE_CREATED.name);
     },
 
+    asyncFunctions: core.asyncFunctions,
+
     requirements: {}
 };
 

--- a/packages/webhook-triggers-app/src/workflows/on-issue-deleted.js
+++ b/packages/webhook-triggers-app/src/workflows/on-issue-deleted.js
@@ -44,5 +44,7 @@ exports.rule = {
         core.sendWebhooks(ctx, EVENTS.ISSUE_DELETED.key, payload, EVENTS.ISSUE_DELETED.name);
     },
 
+    asyncFunctions: core.asyncFunctions,
+
     requirements: {}
 };

--- a/packages/webhook-triggers-app/src/workflows/on-issue-updated.js
+++ b/packages/webhook-triggers-app/src/workflows/on-issue-updated.js
@@ -65,5 +65,7 @@ exports.rule = {
         core.sendWebhooks(ctx, EVENTS.ISSUE_UPDATED.key, payload, EVENTS.ISSUE_UPDATED.name);
     },
 
+    asyncFunctions: core.asyncFunctions,
+
     requirements: {}
 };

--- a/packages/webhook-triggers-app/src/workflows/on-work-item-added.js
+++ b/packages/webhook-triggers-app/src/workflows/on-work-item-added.js
@@ -62,6 +62,8 @@ exports.rule = {
         core.sendWebhooks(ctx, EVENTS.WORK_ITEM_ADDED.key, payload, EVENTS.WORK_ITEM_ADDED.name);
     },
 
+    asyncFunctions: core.asyncFunctions,
+
     requirements: {}
 };
 

--- a/packages/webhook-triggers-app/src/workflows/on-work-item-deleted.js
+++ b/packages/webhook-triggers-app/src/workflows/on-work-item-deleted.js
@@ -61,6 +61,8 @@ exports.rule = {
         core.sendWebhooks(ctx, EVENTS.WORK_ITEM_DELETED.key, payload, EVENTS.WORK_ITEM_DELETED.name);
     },
 
+    asyncFunctions: core.asyncFunctions,
+
     requirements: {}
 };
 

--- a/packages/webhook-triggers-app/src/workflows/on-work-item-updated.js
+++ b/packages/webhook-triggers-app/src/workflows/on-work-item-updated.js
@@ -62,6 +62,8 @@ exports.rule = {
         core.sendWebhooks(ctx, EVENTS.WORK_ITEM_UPDATED.key, payload, EVENTS.WORK_ITEM_UPDATED.name);
     },
 
+    asyncFunctions: core.asyncFunctions,
+
     requirements: {}
 };
 

--- a/packages/webhook-triggers-app/src/workflows/workflow-core.js
+++ b/packages/webhook-triggers-app/src/workflows/workflow-core.js
@@ -14,8 +14,8 @@ const utilsModule = require('./workflow-utils');
 
 exports.parseWebhookUrls = httpModule.parseWebhookUrls;
 exports.getWebhookUrls = httpModule.getWebhookUrls;
-exports.sendWebhook = httpModule.sendWebhook;
 exports.sendWebhooks = httpModule.sendWebhooks;
+exports.asyncFunctions = httpModule.asyncFunctions;
 
 exports.createGuard = guardsModule.createGuard;
 exports.shouldSkipIssue = guardsModule.shouldSkipIssue;

--- a/packages/webhook-triggers-app/src/workflows/workflow-http.js
+++ b/packages/webhook-triggers-app/src/workflows/workflow-http.js
@@ -1,14 +1,26 @@
 /**
- * HTTP and webhook communication utilities for YouTrack workflow rules.
+ * Webhook delivery via async function chain.
+ *
+ * Sync action dispatches URL 1 via postAsync; the response handler
+ * `logAndPostNext` logs the result and dispatches URL 2 via another postAsync,
+ * and so on. Each URL costs one async hop. Server `maxChainLength = 10` by
+ * default, giving the practical cap in {@link MAX_WEBHOOK_URLS_PER_EVENT}.
  */
 
 const http = require('@jetbrains/youtrack-scripting-api/http');
 const security = require('./workflow-security');
 
-/**
- * Timeout for webhook HTTP connections in milliseconds
- */
 const WEBHOOK_TIMEOUT_MS = 5000;
+const MAX_WEBHOOK_URLS_PER_EVENT = 10;
+
+const STORE_URLS = 'webhookUrls';
+const STORE_PAYLOAD = 'webhookPayload';
+const STORE_EVENT = 'webhookEvent';
+const STORE_CURRENT_URL = 'webhookCurrentUrl';
+
+// `webhookToken` is `format: "secret"` — at the JS layer its toString() is
+// the literal "secret", and that's what reaches the wire. Same as the sync
+// baseline; awaits a platform-side fix.
 
 /**
  * Parse comma or newline separated webhook URLs from settings
@@ -19,7 +31,7 @@ function parseWebhookUrls(webhooksStr) {
   if (!webhooksStr || typeof webhooksStr !== 'string') {
     return [];
   }
-  return webhooksStr.split(/[,\n]/)  // Split by comma OR newline
+  return webhooksStr.split(/[,\n]/)
     .map(function (s) {
       return s.trim();
     })
@@ -36,15 +48,12 @@ function parseWebhookUrls(webhooksStr) {
  * @returns {Array<string>} Deduplicated array of webhook URLs
  */
 function getWebhookUrls(ctx, settingsKey) {
-  // Parse event-specific webhooks
   const webhooksStr = ctx.settings[settingsKey] || '';
   const eventUrls = parseWebhookUrls(webhooksStr);
 
-  // Parse "All Events" webhooks
   const allEventsWebhooksStr = ctx.settings.webhooksOnAllEvents || '';
   const allEventsUrls = parseWebhookUrls(allEventsWebhooksStr);
 
-  // Combine and deduplicate
   const urlSet = {};
   const allUrls = [];
 
@@ -66,78 +75,106 @@ function getWebhookUrls(ctx, settingsKey) {
 }
 
 /**
- * Logs webhook response details
- * @param {Object} postResult - The HTTP response object
- * @param {string} url - The webhook URL
+ * Logs the outcome of a single webhook delivery.
+ * @param {Object} response - ctx.response from the postAsync handler
+ * @param {string} url - The webhook URL that was hit
  */
-function logWebhookResponse(postResult, url) {
-  if (postResult && !postResult.code) {
+function logWebhookResponse(response, url) {
+  if (!response) {
+    console.warn('[webhooks] No response object received for ' + url);
+    return;
+  }
+  if (response.exception) {
+    console.error('[webhooks] Webhook to ' + url + ' failed: ' + response.exception);
+    return;
+  }
+  if (!response.code) {
     console.warn('[webhooks] Webhook request to ' + url + ' completed but returned no status code (likely timeout after ' + WEBHOOK_TIMEOUT_MS + 'ms)');
     return;
   }
-  
+
   console.log('[webhooks] Webhook sent successfully to ' + url);
-  if (postResult) {
-    console.log('[webhooks] Response code: ' + (postResult.code || 'unknown'));
-    // Response body is intentionally not logged to prevent exposure of data
-    // from internal services reachable from the YouTrack server (SSRF).
-  }
+  console.log('[webhooks] Response code: ' + response.code);
+  // Response body not logged — SSRF: receivers may reflect internal data.
 }
 
 /**
- * Logs webhook error details
- * @param {Error} error - The error object
- * @param {string} url - The webhook URL
+ * Validates a URL, persists post-dispatch state, then fires postAsync with
+ * `logAndPostNext` as the response handler. Stores BEFORE scheduling per
+ * the async-functions "store before invoke" guidance.
+ * @returns {boolean} true on scheduled, false on rejection (caller may retry next URL).
  */
-function logWebhookError(error, url) {
-  console.error('[webhooks] Failed to send webhook to ' + url);
-  const errorMessage = error.message || error.toString() || 'Unknown error';
-  const errorStack = error.stack || 'No stack trace';
-  console.error('[webhooks] Error: ' + errorMessage);
-  console.error('[webhooks] Error stack: ' + errorStack);
-}
-
-/**
- * Sends a webhook to a single URL
- * @param {string} url - The webhook URL
- * @param {Object} payload - The data to send
- * @param {string} eventName - Name of the event for logging
- * @param {string} [token] - Token for authentication header
- * @param {string} [headerName] - Name of the HTTP header for the token
- * @returns {Object|null} The HTTP response or null on error
- */
-function sendWebhook(url, payload, eventName, token, headerName) {
-  const trimmedUrl = url.trim();
-  const validation = security.validateWebhookUrl(trimmedUrl);
+function tryPostWebhook(ctx, url, remainingUrls, token, headerName, payloadJson) {
+  const validation = security.validateWebhookUrl(url);
   if (!validation.valid) {
-    console.error('[webhooks] Blocked webhook to ' + trimmedUrl + ': ' + validation.reason);
-    return null;
+    console.error('[webhooks] Blocked webhook to ' + url + ': ' + validation.reason);
+    return false;
   }
 
-  if (trimmedUrl.startsWith('http://')) {
-    console.warn('[webhooks] Warning: webhook URL uses HTTP (not HTTPS) — the webhook token will be transmitted in plaintext. HTTPS is strongly recommended: ' + trimmedUrl);
+  if (url.startsWith('http://')) {
+    console.warn('[webhooks] Warning: webhook URL uses HTTP (not HTTPS) — the webhook token will be transmitted in plaintext. HTTPS is strongly recommended: ' + url);
   }
+
+  ctx.store(STORE_URLS, JSON.stringify(remainingUrls));
+  ctx.store(STORE_CURRENT_URL, url);
+
   try {
-    const connection = new http.Connection(trimmedUrl, null, WEBHOOK_TIMEOUT_MS);
+    const connection = new http.Connection(url, null, WEBHOOK_TIMEOUT_MS);
     connection.addHeader('Content-Type', 'application/json');
     security.addSecurityHeaders(connection, token, headerName);
-
-    const postResult = connection.postSync('', '', JSON.stringify(payload));
-
-    logWebhookResponse(postResult, trimmedUrl);
-    return postResult;
+    connection.postAsync('', '', payloadJson, 'logAndPostNext');
+    return true;
   } catch (error) {
-    logWebhookError(error, trimmedUrl);
-    return null;
+    const errorMessage = error.message || error.toString() || 'Unknown error';
+    console.error('[webhooks] Failed to schedule webhook to ' + url + ': ' + errorMessage);
+    return false;
   }
 }
 
 /**
- * Sends webhooks to all configured URLs
- * @param {Object} ctx - The workflow context
- * @param {string} settingsKey - The key in ctx.settings to get webhook URLs from
- * @param {Object} payload - The data to send
- * @param {string} eventName - Name of the event for logging
+ * Dispatches the next valid URL via postAsync. Invalid URLs are skipped
+ * synchronously without consuming an async hop.
+ * @returns {boolean} true if scheduled, false if no valid URLs remain.
+ */
+function postNextValid(ctx) {
+  const token = ctx.settings.webhookToken;
+  const headerName = ctx.settings.headerName;
+
+  // Fail closed if settings were cleared mid-chain — addHeader silently
+  // skips a falsy token, which would fan out unauthenticated requests.
+  if (!token || !headerName) {
+    console.warn('[webhooks] Webhook token or header was cleared during chain execution; aborting remaining dispatches');
+    return false;
+  }
+
+  const payloadJson = ctx.load(STORE_PAYLOAD);
+  const urlsJson = ctx.load(STORE_URLS);
+  const urls = urlsJson ? JSON.parse(urlsJson) : [];
+
+  while (urls.length > 0) {
+    const url = urls.shift();
+    if (tryPostWebhook(ctx, url, urls, token, headerName, payloadJson)) {
+      return true;
+    }
+  }
+
+  ctx.store(STORE_URLS, JSON.stringify(urls));
+  return false;
+}
+
+/**
+ * Response handler for each postAsync. Logs the previous response and
+ * dispatches the next URL.
+ */
+function logAndPostNext(ctx) {
+  const url = ctx.load(STORE_CURRENT_URL);
+  logWebhookResponse(ctx.response, url);
+  postNextValid(ctx);
+}
+
+/**
+ * Schedules webhooks via the async function chain. Call from a rule's sync
+ * `action`. The rule must declare `asyncFunctions: core.asyncFunctions`.
  */
 function sendWebhooks(ctx, settingsKey, payload, eventName) {
   const token = ctx.settings.webhookToken || null;
@@ -152,7 +189,6 @@ function sendWebhooks(ctx, settingsKey, payload, eventName) {
     return;
   }
 
-  // Get all URLs (event-specific + "All Events", deduplicated)
   const allUrls = getWebhookUrls(ctx, settingsKey);
 
   if (allUrls.length === 0) {
@@ -160,14 +196,45 @@ function sendWebhooks(ctx, settingsKey, payload, eventName) {
     return;
   }
 
-  console.log('[webhooks] Sending webhooks to ' + allUrls.length + ' URL(s)');
-  allUrls.forEach(function (url) {
-    sendWebhook(url, payload, eventName, token, headerName);
+  // Filter invalid URLs first so the cap applies to URLs that can actually be dispatched.
+  const validUrls = allUrls.filter(function (url) {
+    const validation = security.validateWebhookUrl(url);
+    if (!validation.valid) {
+      console.error('[webhooks] Blocked webhook to ' + url + ': ' + validation.reason);
+      return false;
+    }
+    return true;
   });
+
+  if (validUrls.length === 0) {
+    console.log('[webhooks] No valid webhook URLs for ' + eventName);
+    return;
+  }
+
+  let urls = validUrls;
+  if (validUrls.length > MAX_WEBHOOK_URLS_PER_EVENT) {
+    console.warn('[webhooks] ' + validUrls.length + ' valid URLs configured for ' + eventName + ' but max is ' + MAX_WEBHOOK_URLS_PER_EVENT + ' per event (async chain limit). Extra URLs dropped.');
+    urls = validUrls.slice(0, MAX_WEBHOOK_URLS_PER_EVENT);
+  }
+
+  ctx.store(STORE_URLS, JSON.stringify(urls));
+  ctx.store(STORE_PAYLOAD, JSON.stringify(payload));
+  ctx.store(STORE_EVENT, eventName);
+
+  console.log('[webhooks] Scheduling ' + urls.length + ' webhook(s) for ' + eventName);
+  postNextValid(ctx);
 }
+
+const asyncFunctions = {
+  logAndPostNext: logAndPostNext,
+};
 
 exports.parseWebhookUrls = parseWebhookUrls;
 exports.getWebhookUrls = getWebhookUrls;
-exports.sendWebhook = sendWebhook;
 exports.sendWebhooks = sendWebhooks;
-
+exports.logAndPostNext = logAndPostNext;
+exports.logWebhookResponse = logWebhookResponse;
+exports.postNextValid = postNextValid;
+exports.asyncFunctions = asyncFunctions;
+exports.MAX_WEBHOOK_URLS_PER_EVENT = MAX_WEBHOOK_URLS_PER_EVENT;
+exports.WEBHOOK_TIMEOUT_MS = WEBHOOK_TIMEOUT_MS;


### PR DESCRIPTION
Outbound HTTP now runs in async function hops instead of the originating user transaction. Each URL = 1 hop; chain cap = 10 URLs/event.

- sync action dispatches URL (1) via connection.postAsync(handler='logAndPostNext')
- logAndPostNext logs ctx.response, dispatches next URL via postAsync
- token/headerName re-read from ctx.settings each hop (avoid ctx.store toString coercion of SecretAttributeValue); fail-closed if either cleared mid-chain
- chain state stored BEFORE postAsync per the async-functions store-before-invoke guidance
- invalid URL skipped synchronously (no hop consumed)

asyncFunctions wired into all 11 on-*.js rule files.

Test scaffolding: Connection mock with postAsync/postSync recording (shared via globalThis across the ESM/CJS dual-load), ctx test helper, 33 unit tests.