### PR TITLE
JT-95004 fix(webhook-triggers-app): enforce minLength of 32 for webhook token setting

### DIFF
--- a/packages/webhook-triggers-app/src/settings.json
+++ b/packages/webhook-triggers-app/src/settings.json
@@ -10,7 +10,8 @@
       "description": "The webhook token is a shared secret included in requests to all webhook URLs configured in this project. Only add endpoints you trust. Rotate this token immediately if any recipient is decommissioned or a compromise is suspected. Must be at least 32 characters long.",
       "type": "string",
       "format": "secret",
-      "x-scope": "PROJECT"
+      "x-scope": "PROJECT",
+      "minLength": 32
     },
     "headerName": {
       "title": "Header name",


### PR DESCRIPTION
Original security concern: [JT-95004](https://youtrack.jetbrains.com/issue/JT-95004) Webhook Triggers App: token minimum length not enforced in schema

Backend fix for secrets: [JT-95518](https://youtrack.jetbrains.com/issue/JT-95518) Saving app settings fails when a secret setting is present due to mask value failing schema validation

Our follow-up that will eliminate the security issue in the first place -- there will be no shared secrets: [JT-96096](https://youtrack.jetbrains.com/issue/JT-96096) Research "APP_SETTINGS_WIDGET" extension point possibility