### PR TITLE
JT-96765 add with store curry helper

### DIFF
--- a/packages/apps-tools/package.json
+++ b/packages/apps-tools/package.json
@@ -141,11 +141,12 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "lint": "eslint",
-    "test": "npm run build && npm run test:dx && npm run test:cli",
+    "test": "npm run build && npm run typecheck:regression && npm run typecheck:types && npm run test:dx && npm run test:cli",
     "test:dx": "node --test --import tsx src/dx/test/*.test.ts",
     "test:cli": "jest",
     "test:type": "tsc --noEmit",
     "typecheck:types": "tsc --noEmit -p src/dx/test/types-strict-tsconfig.json",
+    "typecheck:regression": "tsc --noEmit -p src/dx/test/regression/regression-tsconfig.json",
     "save-version": "echo '{ \"version\": \"'$npm_package_version'\" }' > dist/package.json",
     "release:ci": "commit-and-tag-version && git push --follow-tags origin main && npm run save-version && npm publish"
   },

--- a/packages/apps-tools/src/dx/index.ts
+++ b/packages/apps-tools/src/dx/index.ts
@@ -13,3 +13,4 @@ export * from './types/index.js';
 
 // Utilities
 export { withPermissions } from './utility/withPermissions.js';
+export { withStore } from './utility/withStore.js';

--- a/packages/apps-tools/src/dx/runtime.ts
+++ b/packages/apps-tools/src/dx/runtime.ts
@@ -4,5 +4,6 @@
 
 export * from './types/index.js';
 export { withPermissions } from './utility/withPermissions.js';
+export { withStore } from './utility/withStore.js';
 export { set } from './utility/set.js';
 export type { KnownKeys, ExtensionValue } from './utility/set.js';

--- a/packages/apps-tools/src/dx/test/regression/action-ctx-async-split.ts
+++ b/packages/apps-tools/src/dx/test/regression/action-ctx-async-split.ts
@@ -14,7 +14,7 @@ import { Issue } from '@jetbrains/youtrack-workflow-types/workflowTypeScriptStub
 
 const requirements = { Stage: { type: 'string' } } as const;
 
-Issue.onChange<{ url: string }, typeof requirements, 'onResponse'>({
+Issue.onChange<typeof requirements, 'onResponse', { url: string }>({
   requirements,
   action: (ctx) => {
     ctx.store('url', 'https://example.com'); // available in sync action

--- a/packages/apps-tools/src/dx/test/regression/action-ctx-async-split.ts
+++ b/packages/apps-tools/src/dx/test/regression/action-ctx-async-split.ts
@@ -1,0 +1,31 @@
+// Regression fixture — JT-96565 finding 3.
+//
+// `ctx.response` is the incoming HTTP response, populated by the runtime only
+// when a function runs as an async HTTP-response callback. It must not appear on
+// the synchronous `action` context, where it is always absent. `store` / `load`
+// / `invokeAsync` share the same runtime gate (an async-enabled rule) and stay
+// available in both the sync action and the async functions.
+//
+// Generics are fully explicit so R is a concrete requirement type rather than
+// the default catch-all index — that is what makes the absence of `response`
+// on the sync context observable.
+
+import { Issue } from '@jetbrains/youtrack-workflow-types/workflowTypeScriptStubs';
+
+const requirements = { Stage: { type: 'string' } } as const;
+
+Issue.onChange<{ url: string }, typeof requirements, 'onResponse'>({
+  requirements,
+  action: (ctx) => {
+    ctx.store('url', 'https://example.com'); // available in sync action
+    ctx.invokeAsync('onResponse');
+    // @ts-expect-error response is only available inside async callbacks
+    void ctx.response;
+  },
+  asyncFunctions: {
+    onResponse: (ctx) => {
+      void ctx.load('url'); // available in async function
+      void ctx.response; // populated for HTTP-response callbacks
+    }
+  }
+});

--- a/packages/apps-tools/src/dx/test/regression/define-aitool-plain.ts
+++ b/packages/apps-tools/src/dx/test/regression/define-aitool-plain.ts
@@ -1,0 +1,39 @@
+// Regression fixture — JT-96765 finding 1.
+//
+// `defineAITool<TArgs, TResult>({...})` (no async functions, no store schema)
+// is the original public shape. The async-surface sync replaced it with a
+// single overload that requires `S`, `AK`, and an `asyncFunctions` block, so
+// plain tools stopped compiling. Both shapes must compile.
+
+import { defineAITool } from '@jetbrains/youtrack-workflow-types/ai-tools';
+
+type Args = { query: string };
+
+// Plain tool: two type args, no asyncFunctions.
+const plain = defineAITool<Args, string>({
+  name: 'search',
+  description: 'Search issues',
+  execute: (ctx) => {
+    const q: string = ctx.arguments.query; // arguments typed as Args
+    return q;
+  }
+});
+void plain;
+
+// Async/store tool: the narrowing overload still works alongside it.
+const withAsync = defineAITool<Args, string, { last: string }, 'onDone'>({
+  name: 'search',
+  description: 'Search issues',
+  execute: (ctx) => {
+    ctx.store('last', ctx.arguments.query);
+    ctx.invokeAsync('onDone');
+    return 'ok';
+  },
+  asyncFunctions: {
+    onDone: (ctx) => {
+      const v: string | undefined = ctx.load('last');
+      void v;
+    }
+  }
+});
+void withAsync;

--- a/packages/apps-tools/src/dx/test/regression/define-aitool-plain.ts
+++ b/packages/apps-tools/src/dx/test/regression/define-aitool-plain.ts
@@ -1,27 +1,29 @@
-// Regression fixture — JT-96765 finding 1.
+// Regression fixture — JT-96765 AI tool authoring shapes.
 //
-// `defineAITool<TArgs, TResult>({...})` (no async functions, no store schema)
-// is the original public shape. The async-surface sync replaced it with a
-// single overload that requires `S`, `AK`, and an `asyncFunctions` block, so
-// plain tools stopped compiling. Both shapes must compile.
+// The typings module is type-only: there is no `defineAITool` runtime value.
+//   - Plain tool (no async, no store): `{...} satisfies AITool<TArgs, TResult>`.
+//   - Async/store tool: the `withStore<TArgs, TResult, S>()` curry (runtime
+//     identity; AK inferred from `asyncFunctions`).
+// Both shapes must compile.
 
-import { defineAITool } from '@jetbrains/youtrack-workflow-types/ai-tools';
+import type { AITool } from '@jetbrains/youtrack-workflow-types/ai-tools';
+import { withStore } from '../../utility/withStore.js';
 
 type Args = { query: string };
 
-// Plain tool: two type args, no asyncFunctions.
-const plain = defineAITool<Args, string>({
+// Plain tool: types arguments + result, no asyncFunctions.
+const plain = {
   name: 'search',
   description: 'Search issues',
   execute: (ctx) => {
     const q: string = ctx.arguments.query; // arguments typed as Args
     return q;
   }
-});
+} satisfies AITool<Args, string>;
 void plain;
 
-// Async/store tool: the narrowing overload still works alongside it.
-const withAsync = defineAITool<Args, string, { last: string }, 'onDone'>({
+// Async/store tool via the curry: store typed against S, AK inferred.
+const withAsync = withStore<Args, string, { last: string }>()({
   name: 'search',
   description: 'Search issues',
   execute: (ctx) => {

--- a/packages/apps-tools/src/dx/test/regression/http-sync-uri.ts
+++ b/packages/apps-tools/src/dx/test/regression/http-sync-uri.ts
@@ -1,0 +1,20 @@
+// Regression fixture — JT-96765 finding 4.
+//
+// The synchronous Connection methods take an optional `uri`; calling them with
+// no URI targets the Connection's base URL. The async-surface sync regressed
+// `uri` to a required `string | undefined`, breaking these calls. This fixture
+// must compile.
+
+import type { Connection } from '@jetbrains/youtrack-workflow-types/http';
+
+declare const conn: Connection;
+
+conn.getSync();
+conn.headSync();
+conn.deleteSync();
+conn.connectSync();
+conn.optionsSync();
+conn.postSync();
+conn.putSync();
+conn.patchSync();
+conn.doSync('GET');

--- a/packages/apps-tools/src/dx/test/regression/regression-tsconfig.json
+++ b/packages/apps-tools/src/dx/test/regression/regression-tsconfig.json
@@ -5,9 +5,14 @@
     "moduleResolution": "bundler",
     "strict": true,
     "noEmit": true,
-    "skipLibCheck": false,
+    "skipLibCheck": true,
     "esModuleInterop": true,
     "types": ["@jetbrains/youtrack-workflow-types/scripting-api"]
   },
-  "include": ["./types-strict-consumer.ts", "./withStore-aitool-compile.ts", "./withStore-http-compile.ts"]
+  "include": [
+    "./http-sync-uri.ts",
+    "./define-aitool-plain.ts",
+    "./rule-requirements-generics.ts",
+    "./action-ctx-async-split.ts"
+  ]
 }

--- a/packages/apps-tools/src/dx/test/regression/rule-requirements-generics.ts
+++ b/packages/apps-tools/src/dx/test/regression/rule-requirements-generics.ts
@@ -1,18 +1,22 @@
-// Regression fixture — JT-96565 rule factory generics (S-first design).
+// Regression fixture — JT-96565 rule factory generics (R-first, additive).
 //
-// Rule factories lead with the store schema: static onChange<S, R, AK>,
-// matching the app factories where S precedes AK (defineHttpHandler<S, AK>,
-// defineAITool<…, S, AK>). The factory threads the generics into
-// RuleProperties<R, AK, S> by name, so the consumer-facing shape stays R-first.
+// Rule factories keep the published R-first shape: static onChange<R, AK, S>,
+// where AK and S are trailing defaulted params. This is additive over the
+// shipped `@jetbrains/youtrack-workflow-types` (`onChange<R>`): existing code
+// that names only the requirements keeps working, and ctx requirement typing is
+// preserved. Store/async typing lives behind the `withStore` curry, not the
+// factory generics.
 //
 // TypeScript turns off inference for the remaining params once any type arg is
-// supplied, so use one of two forms:
-//   - No explicit generics: R and AK are inferred from `requirements` /
+// supplied, so use one of these forms:
+//   - No explicit generics: R and AK inferred from `requirements` /
 //     `asyncFunctions`; the store stays loosely typed.
-//   - All three explicit: store, requirements, and async keys are all typed.
-// (Naming only the store would drop R and AK to their defaults.)
+//   - Requirements only (`onChange<R>`): the published shape — requirement
+//     context typed, store/async left at defaults.
+//   - All three explicit (`onChange<R, AK, S>`): requirements, async keys, and
+//     store schema all typed.
 
-import { Issue } from '@jetbrains/youtrack-workflow-types/workflowTypeScriptStubs';
+import { Issue, User } from '@jetbrains/youtrack-workflow-types/workflowTypeScriptStubs';
 
 const requirements = { Assignee: { type: 'user' } } as const;
 
@@ -24,8 +28,20 @@ Issue.onChange({
   }
 });
 
-// All generics explicit: store schema typed alongside requirements + async keys.
-Issue.onChange<{ count: number }, typeof requirements, 'onDone'>({
+// Published shape — requirements as the single generic (back-compat). The
+// requirement context must stay typed; `MyRequirements` must NOT be consumed as
+// the store schema (the store stays loose).
+type MyRequirements = { Assignee: { type: 'user' } };
+Issue.onChange<MyRequirements>({
+  requirements,
+  action: (ctx) => {
+    void ctx.Assignee;        // requirement context, not store
+    ctx.store('anything', 1); // store loose: arbitrary key accepted
+  }
+});
+
+// All generics explicit (R-first): requirements + async keys + store schema.
+Issue.onChange<typeof requirements, 'onDone', { count: number }>({
   requirements,
   action: (ctx) => {
     void ctx.Assignee;          // requirement context
@@ -38,4 +54,21 @@ Issue.onChange<{ count: number }, typeof requirements, 'onDone'>({
       void v;
     }
   }
+});
+
+// Store schema with an entity value type round-trips (entity references are
+// preserved by the runtime).
+Issue.onChange<typeof requirements, 'onDone', { owner: User }>({
+  requirements,
+  action: (ctx) => { ctx.store('owner', ctx.currentUser); ctx.invokeAsync('onDone'); },
+  asyncFunctions: { onDone: (ctx) => { void ctx.load('owner'); } }
+});
+
+// A store schema whose value type cannot survive the runtime round-trip
+// (a nested object) must be rejected by the `AsyncStoreValue` constraint.
+// @ts-expect-error - { ts: number } is not an AsyncStoreValue
+Issue.onChange<typeof requirements, 'onDone', { payload: { ts: number } }>({
+  requirements,
+  action: (ctx) => { ctx.invokeAsync('onDone'); },
+  asyncFunctions: { onDone: () => {} }
 });

--- a/packages/apps-tools/src/dx/test/regression/rule-requirements-generics.ts
+++ b/packages/apps-tools/src/dx/test/regression/rule-requirements-generics.ts
@@ -1,0 +1,41 @@
+// Regression fixture — JT-96565 rule factory generics (S-first design).
+//
+// Rule factories lead with the store schema: static onChange<S, R, AK>,
+// matching the app factories where S precedes AK (defineHttpHandler<S, AK>,
+// defineAITool<…, S, AK>). The factory threads the generics into
+// RuleProperties<R, AK, S> by name, so the consumer-facing shape stays R-first.
+//
+// TypeScript turns off inference for the remaining params once any type arg is
+// supplied, so use one of two forms:
+//   - No explicit generics: R and AK are inferred from `requirements` /
+//     `asyncFunctions`; the store stays loosely typed.
+//   - All three explicit: store, requirements, and async keys are all typed.
+// (Naming only the store would drop R and AK to their defaults.)
+
+import { Issue } from '@jetbrains/youtrack-workflow-types/workflowTypeScriptStubs';
+
+const requirements = { Assignee: { type: 'user' } } as const;
+
+// Full inference: requirement context is typed; the store stays loose.
+Issue.onChange({
+  requirements,
+  action: (ctx) => {
+    void ctx.Assignee;
+  }
+});
+
+// All generics explicit: store schema typed alongside requirements + async keys.
+Issue.onChange<{ count: number }, typeof requirements, 'onDone'>({
+  requirements,
+  action: (ctx) => {
+    void ctx.Assignee;          // requirement context
+    ctx.store('count', 1);      // typed against the store schema
+    ctx.invokeAsync('onDone');  // narrowed to the declared async key
+  },
+  asyncFunctions: {
+    onDone: (ctx) => {
+      const v: number | undefined = ctx.load('count');
+      void v;
+    }
+  }
+});

--- a/packages/apps-tools/src/dx/test/withStore-aitool-compile.ts
+++ b/packages/apps-tools/src/dx/test/withStore-aitool-compile.ts
@@ -1,0 +1,37 @@
+// Compile-time fixture for `withStore` AI tool overload.
+//
+// Expected to compile cleanly under tsc. If the AI overload is missing or
+// regresses, tsc fails on this file.
+//
+// Asserts:
+//   - withStore<Args, TResult, S>() accepts 3 explicit type args
+//   - The returned function infers AK from `asyncFunctions` keys
+//   - ctx.arguments is typed as Args
+//   - ctx.store / ctx.load are typed against S
+//   - ctx.invokeAsync narrowed to declared AK union
+//   - asyncFunctions is required (intersection forces it)
+
+import { withStore } from '../utility/withStore.js';
+
+type Args = { query: string };
+type MyStore = { last: string; count: number };
+
+const tool = withStore<Args, string, MyStore>()({
+  name: 'search',
+  description: 'd',
+  execute: (ctx) => {
+    const q: string = ctx.arguments.query;       // typed as Args
+    ctx.store('last', q);                          // typed against MyStore
+    ctx.store('count', 1);                         // typed
+    ctx.invokeAsync('onDone');                     // narrowed: 'onDone'
+    return 'ok';
+  },
+  asyncFunctions: {
+    onDone: (ctx) => {
+      const v: string | undefined = ctx.load('last');  // typed
+      console.log(v);
+    }
+  }
+});
+
+console.log(tool);

--- a/packages/apps-tools/src/dx/test/withStore-http-compile.ts
+++ b/packages/apps-tools/src/dx/test/withStore-http-compile.ts
@@ -1,0 +1,57 @@
+// Compile-time fixture for `withStore` HTTP handler overload.
+//
+// Expected to compile cleanly under tsc. The positive lines fail if the overload
+// regresses; the `@ts-expect-error` lines fail (unused directive) if the narrowing
+// weakens. Wired via src/dx/test/types-strict-tsconfig.json (`npm run typecheck:types`).
+//
+// Asserts:
+//   - withStore<S>() selects the HTTP overload (1 explicit type arg)
+//   - AK is inferred from `asyncFunctions` keys (no manual union)
+//   - ctx.store / ctx.load are typed against S in both the sync handle and the async ctx
+//   - ctx.invokeAsync is narrowed to the declared AK union
+//   - asyncFunctions is required (the intersection forces it)
+
+import { withStore } from '../utility/withStore.js';
+
+type MyStore = { count: number; label: string };
+
+const httpHandler = withStore<MyStore>()({
+  endpoints: [
+    {
+      scope: 'global',
+      method: 'POST',
+      path: '/tick',
+      handle: (ctx) => {
+        ctx.store('count', 1); // typed: S['count'] = number
+        ctx.store('label', 'hello'); // typed: S['label'] = string
+        const c: number | undefined = ctx.load('count'); // typed against S
+        void c;
+
+        ctx.invokeAsync('onTick'); // narrowed: 'onTick' | 'onDone'
+        ctx.invokeAsync('onDone');
+
+        // @ts-expect-error - value must match S['count'] (number, not string)
+        ctx.store('count', 'not-a-number');
+        // @ts-expect-error - 'missing' is not a key of S
+        ctx.store('missing', 1);
+        // @ts-expect-error - 'unknownFn' is not a declared async function key
+        ctx.invokeAsync('unknownFn');
+
+        ctx.response.json({ ok: true });
+      },
+    },
+  ],
+  asyncFunctions: {
+    onTick: (ctx) => {
+      const v: number | undefined = ctx.load('count'); // typed against S
+      void v;
+      // @ts-expect-error - 'missing' is not a key of S
+      ctx.load('missing');
+    },
+    onDone: (ctx) => {
+      ctx.store('label', 'done'); // typed against S
+    },
+  },
+});
+
+console.log(httpHandler);

--- a/packages/apps-tools/src/dx/test/withStore.test.ts
+++ b/packages/apps-tools/src/dx/test/withStore.test.ts
@@ -1,0 +1,48 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { withStore } from '../utility/withStore.js';
+
+describe('withStore', () => {
+  it('returns the handler unchanged at runtime (identity curry)', () => {
+    const handler = { endpoints: [], asyncFunctions: { onDone: () => {} } };
+    const result = withStore<{ a: string }>()(handler as never);
+    assert.strictEqual(result, handler);
+  });
+
+  it('first call returns a callable (no extra side effects)', () => {
+    const bind = withStore<{ a: string }>();
+    assert.strictEqual(typeof bind, 'function');
+  });
+
+  it('accepts AI tool via 3-generic overload (TArgs, TResult, S)', () => {
+    const tool = {
+      name: 't',
+      description: 'd',
+      execute: () => 'ok',
+      asyncFunctions: { onResult: () => {} }
+    };
+    const result = withStore<{ q: string }, string, { last: string }>()(tool as never);
+    assert.strictEqual(result, tool);
+  });
+
+  it('first call of 3-generic AI overload returns a callable', () => {
+    const bind = withStore<{ q: string }, string, { last: string }>();
+    assert.strictEqual(typeof bind, 'function');
+  });
+
+  it('accepts HTTP handler shape', () => {
+    const handler = {
+      endpoints: [
+        {
+          scope: 'global',
+          method: 'POST',
+          path: '/tick',
+          handle: () => {}
+        }
+      ],
+      asyncFunctions: { onTick: () => {} }
+    };
+    const result = withStore<{ count: number }>()(handler as never);
+    assert.strictEqual(result, handler);
+  });
+});

--- a/packages/apps-tools/src/dx/utility/withStore.ts
+++ b/packages/apps-tools/src/dx/utility/withStore.ts
@@ -1,0 +1,79 @@
+import type { HttpHandler, HttpAsyncFunctionContext, AppTypeRegistry } from '@jetbrains/youtrack-workflow-types/apps';
+import type { AITool, AIToolAsyncFunctionContext } from '@jetbrains/youtrack-workflow-types/ai-tools';
+
+/**
+ * Curry helper for the async-functions surface. First call binds the store
+ * schema (and, for AI tools, the argument/result types); the returned
+ * function has no explicit generics, so AK is inferred from the
+ * `asyncFunctions` literal — both narrowings active in a single bare call
+ * site, no manual key union required.
+ *
+ * Sidesteps the TS partial-inference limit hit by the explicit
+ * `defineHttpHandler<S, AK>({...})` / `defineAITool<TArgs, TResult, S, AK>({...})`
+ * forms, where supplying explicit type args would force the caller to also
+ * list the AK union by hand.
+ *
+ * Two overloads, selected by generic arg count:
+ *   - `withStore<S>()` → HTTP handler curry
+ *   - `withStore<TArgs, TResult, S>()` → AI tool curry (binds `TArgs`/`TResult`
+ *     explicitly to avoid the inference foot-gun where they would silently
+ *     fall back to `Record<string, unknown>`)
+ *
+ * @example
+ * ```typescript
+ * import { withStore } from '@jetbrains/youtrack-apps-tools/dx/runtime';
+ *
+ * type MyStore = { count: number; label: string };
+ *
+ * // HTTP handler:
+ * exports.httpHandler = withStore<MyStore>()({
+ *   endpoints: [{
+ *     scope: 'global', method: 'POST', path: '/tick',
+ *     handle: (ctx) => {
+ *       ctx.store('count', 1);                // typed: number
+ *       ctx.invokeAsync('onTick');            // narrowed
+ *       ctx.response.json({});
+ *     }
+ *   }],
+ *   asyncFunctions: {
+ *     onTick: (ctx) => { console.log(ctx.load('count')); },
+ *     onDone: (ctx) => { console.log(ctx); }
+ *   }
+ * });
+ *
+ * // AI tool:
+ * type Args = { query: string };
+ * exports.aiTool = withStore<Args, string, MyStore>()({
+ *   name: 'search', description: 'd',
+ *   execute: (ctx) => {
+ *     ctx.store('label', ctx.arguments.query);
+ *     ctx.invokeAsync('onResult');
+ *     return 'ok';
+ *   },
+ *   asyncFunctions: { onResult: (ctx) => { console.log(ctx.load('label')); } }
+ * });
+ * ```
+ */
+export function withStore<S extends object>(): <
+  AK extends string,
+  TSettings = AppTypeRegistry['settings'],
+  TIssueExtensions = AppTypeRegistry['issueExtensions'],
+  TProjectExtensions = AppTypeRegistry['projectExtensions'],
+  TArticleExtensions = AppTypeRegistry['articleExtensions'],
+  TUserExtensions = AppTypeRegistry['userExtensions'],
+  TGlobalStorageExtensions = AppTypeRegistry['appGlobalStorageExtensions']
+>(
+  handler: HttpHandler<TSettings, TIssueExtensions, TProjectExtensions, TArticleExtensions, TUserExtensions, TGlobalStorageExtensions, AK, S>
+    & { asyncFunctions: Record<AK, (ctx: HttpAsyncFunctionContext<TSettings, TIssueExtensions, TProjectExtensions, TArticleExtensions, TUserExtensions, TGlobalStorageExtensions, AK, S>) => void> }
+) => HttpHandler<TSettings, TIssueExtensions, TProjectExtensions, TArticleExtensions, TUserExtensions, TGlobalStorageExtensions, AK, S>;
+export function withStore<TArgs, TResult, S extends object>(): <
+  AK extends string,
+  TSettings = AppTypeRegistry['settings'],
+  TGlobalStorageExtensions = AppTypeRegistry['appGlobalStorageExtensions']
+>(
+  tool: AITool<TArgs, TResult, TSettings, TGlobalStorageExtensions, AK, S>
+    & { asyncFunctions: Record<AK, (ctx: AIToolAsyncFunctionContext<TSettings, TGlobalStorageExtensions, AK, S>) => void> }
+) => AITool<TArgs, TResult, TSettings, TGlobalStorageExtensions, AK, S>;
+export function withStore(): <T>(input: T) => T {
+  return input => input;
+}

--- a/packages/apps-tools/src/dx/utility/withStore.ts
+++ b/packages/apps-tools/src/dx/utility/withStore.ts
@@ -1,5 +1,6 @@
 import type { HttpHandler, HttpAsyncFunctionContext, AppTypeRegistry } from '@jetbrains/youtrack-workflow-types/apps';
 import type { AITool, AIToolAsyncFunctionContext } from '@jetbrains/youtrack-workflow-types/ai-tools';
+import type { AsyncStoreValue } from '@jetbrains/youtrack-workflow-types/workflowTypeScriptStubs';
 
 /**
  * Curry helper for the async-functions surface. First call binds the store
@@ -8,10 +9,10 @@ import type { AITool, AIToolAsyncFunctionContext } from '@jetbrains/youtrack-wor
  * `asyncFunctions` literal — both narrowings active in a single bare call
  * site, no manual key union required.
  *
- * Sidesteps the TS partial-inference limit hit by the explicit
- * `defineHttpHandler<S, AK>({...})` / `defineAITool<TArgs, TResult, S, AK>({...})`
- * forms, where supplying explicit type args would force the caller to also
- * list the AK union by hand.
+ * Sidesteps the TS partial-inference limit: annotating the handler/tool type
+ * directly (or `satisfies HttpHandler<...>` / `satisfies AITool<...>`) cannot
+ * infer AK, so the caller would have to spell out the async key union by hand.
+ * The curry binds the store schema first, then infers AK from `asyncFunctions`.
  *
  * Two overloads, selected by generic arg count:
  *   - `withStore<S>()` → HTTP handler curry
@@ -54,7 +55,7 @@ import type { AITool, AIToolAsyncFunctionContext } from '@jetbrains/youtrack-wor
  * });
  * ```
  */
-export function withStore<S extends object>(): <
+export function withStore<S extends Record<keyof S, AsyncStoreValue>>(): <
   AK extends string,
   TSettings = AppTypeRegistry['settings'],
   TIssueExtensions = AppTypeRegistry['issueExtensions'],
@@ -66,7 +67,7 @@ export function withStore<S extends object>(): <
   handler: HttpHandler<TSettings, TIssueExtensions, TProjectExtensions, TArticleExtensions, TUserExtensions, TGlobalStorageExtensions, AK, S>
     & { asyncFunctions: Record<AK, (ctx: HttpAsyncFunctionContext<TSettings, TIssueExtensions, TProjectExtensions, TArticleExtensions, TUserExtensions, TGlobalStorageExtensions, AK, S>) => void> }
 ) => HttpHandler<TSettings, TIssueExtensions, TProjectExtensions, TArticleExtensions, TUserExtensions, TGlobalStorageExtensions, AK, S>;
-export function withStore<TArgs, TResult, S extends object>(): <
+export function withStore<TArgs, TResult, S extends Record<keyof S, AsyncStoreValue>>(): <
   AK extends string,
   TSettings = AppTypeRegistry['settings'],
   TGlobalStorageExtensions = AppTypeRegistry['appGlobalStorageExtensions']

--- a/packages/youtrack-workflow-types/types/ai-tools.d.ts
+++ b/packages/youtrack-workflow-types/types/ai-tools.d.ts
@@ -19,8 +19,14 @@
  * @module @jetbrains/youtrack-scripting-api/ai-tools
  */
 
-import type { Issue, User } from './workflowTypeScriptStubs.js';
+import type { Issue, User, AppGlobalStorage } from './workflowTypeScriptStubs.js';
 import type { JSONSchema } from './utility-types.js';
+// Import HTTP Response type for use as the async HTTP response shape in
+// asyncFunctions called as `connection.*Async(..., 'handlerName')` callbacks.
+import type { Response } from './http.js';
+// AI tools share AppTypeRegistry with apps for settings + globalStorage
+// extension property types.
+import type { AppTypeRegistry } from './apps.js';
 
 // =============================================================================
 // AI Tool Annotations
@@ -76,8 +82,25 @@ export interface AIToolAnnotations {
 
 /**
  * Context available to AI tool execute function.
+ *
+ * Carries AK / S generics so `ctx.invokeAsync` / `ctx.store` / `ctx.load`
+ * are typed against the parent tool's `asyncFunctions` keys and store schema,
+ * matching the rule-side `ActionContext<R, AK, S>` pattern.
+ *
+ * @template TArgs - Input arguments shape parsed from the tool's inputSchema.
+ * @template S - Optional store schema. Default loose.
+ * @template AK - Union of asyncFunctions key names declared on the parent tool.
+ * @template TSettings - App settings type. Defaults to AppTypeRegistry['settings'].
+ * @template TGlobalStorageExtensions - AppGlobalStorage extension properties.
+ *   Defaults to AppTypeRegistry['appGlobalStorageExtensions'].
  */
-export interface AIToolContext<TArgs = Record<string, unknown>> {
+export interface AIToolContext<
+  TArgs = Record<string, unknown>,
+  TSettings = AppTypeRegistry['settings'],
+  TGlobalStorageExtensions = AppTypeRegistry['appGlobalStorageExtensions'],
+  AK extends string = string,
+  S extends object = Record<string, any>
+> {
   /**
    * Input arguments parsed according to inputSchema.
    * Type is inferred from the inputSchema if using json-schema-to-ts.
@@ -93,6 +116,109 @@ export interface AIToolContext<TArgs = Record<string, unknown>> {
    * Issue in context, if available (depends on where tool is invoked).
    */
   readonly issue?: Issue;
+
+  /**
+   * App settings as key-value pairs. Same shape as `BaseHttpContext.settings`.
+   */
+  readonly settings: TSettings;
+
+  /**
+   * The app-level global storage entity. Use
+   * `ctx.globalStorage.extensionProperties.X` to read/write app-global
+   * values defined in the app's `entity-extensions.json`.
+   */
+  readonly globalStorage: AppGlobalStorage & { extensionProperties: TGlobalStorageExtensions };
+
+  /**
+   * Schedules an async function for execution after the current transaction
+   * commits. `functionName` is constrained to the AK union — keys declared
+   * in the parent tool's `asyncFunctions`.
+   *
+   * @param functionName The name of a function declared in `asyncFunctions`.
+   * @param delay Optional delay in milliseconds (default 0, max 7 days).
+   * @param deduplicationKey Optional debounce key.
+   */
+  invokeAsync(functionName: AK, delay?: number, deduplicationKey?: string): void;
+
+  /**
+   * Persists a value across async boundaries. When a store schema `S` is
+   * supplied, key/value are checked against it.
+   */
+  store<K extends keyof S>(key: K, value: S[K]): void;
+
+  /**
+   * Retrieves a value previously stored with `ctx.store(key, value)`.
+   * Returns `S[K] | undefined`.
+   */
+  load<K extends keyof S>(key: K): S[K] | undefined;
+}
+
+/**
+ * Context passed to async functions declared in an AI tool's `asyncFunctions`
+ * block.
+ *
+ * The function may be invoked via `ctx.invokeAsync('name', delay)` from the
+ * tool's `execute` (or another async function), or as the response callback
+ * of `connection.*Async(..., 'name')`. In the latter case `response` is
+ * populated with the incoming HTTP response.
+ */
+export interface AIToolAsyncFunctionContext<
+  TSettings = AppTypeRegistry['settings'],
+  TGlobalStorageExtensions = AppTypeRegistry['appGlobalStorageExtensions'],
+  AK extends string = string,
+  S extends object = Record<string, any>
+> {
+  /**
+   * Current user under which the async function executes — captured at
+   * scheduling time.
+   */
+  readonly currentUser: User;
+
+  /**
+   * App settings as key-value pairs. Same shape as `AIToolContext.settings`.
+   */
+  readonly settings: TSettings;
+
+  /**
+   * The app-level global storage entity. Use
+   * `ctx.globalStorage.extensionProperties.X` to read/write app-global
+   * values defined in the app's `entity-extensions.json`.
+   */
+  readonly globalStorage: AppGlobalStorage & { extensionProperties: TGlobalStorageExtensions };
+
+  /**
+   * Issue in context, if the tool was invoked with an issue and the value
+   * was carried into the async chain.
+   */
+  readonly issue?: Issue;
+
+  /**
+   * The HTTP response returned by the async HTTP call that triggered this
+   * function (e.g. `connection.postAsync(..., 'onResponse')`). `undefined`
+   * when the function was scheduled via `ctx.invokeAsync`.
+   *
+   * Body is truncated by the runtime at 1 MB.
+   */
+  readonly response?: Response;
+
+  /**
+   * Schedules another async function for execution. `functionName` is
+   * constrained to the AK union (keys declared in the parent tool's
+   * `asyncFunctions`).
+   */
+  invokeAsync(functionName: AK, delay?: number, deduplicationKey?: string): void;
+
+  /**
+   * Persists a value to be retrieved later with `ctx.load(key)`.
+   * Typed against schema S.
+   */
+  store<K extends keyof S>(key: K, value: S[K]): void;
+
+  /**
+   * Retrieves a value stored earlier in the same async chain.
+   * Returns `S[K] | undefined`.
+   */
+  load<K extends keyof S>(key: K): S[K] | undefined;
 }
 
 // =============================================================================
@@ -122,7 +248,11 @@ export interface AIToolContext<TArgs = Record<string, unknown>> {
  */
 export interface AITool<
   TArgs = Record<string, unknown>,
-  TResult = unknown
+  TResult = unknown,
+  TSettings = AppTypeRegistry['settings'],
+  TGlobalStorageExtensions = AppTypeRegistry['appGlobalStorageExtensions'],
+  AK extends string = string,
+  S extends object = Record<string, any>
 > {
   /**
    * Unique name for the tool (used by AI to invoke it).
@@ -155,11 +285,31 @@ export interface AITool<
   annotations?: AIToolAnnotations;
 
   /**
-   * Execute function that performs the tool's action.
+   * Execute function that performs the tool's action. Ctx generics carry the
+   * AK / S from the parent tool so `ctx.invokeAsync` / `ctx.store` /
+   * `ctx.load` are typed against the tool's `asyncFunctions` keys and
+   * store schema.
+   *
    * @param ctx Context containing arguments and other contextual info
    * @returns Result to return to AI (will be JSON serialized)
    */
-  execute: (ctx: AIToolContext<TArgs>) => TResult | Promise<TResult>;
+  execute: (ctx: AIToolContext<TArgs, TSettings, TGlobalStorageExtensions, AK, S>) => TResult | Promise<TResult>;
+
+  /**
+   * Named async functions invoked after the tool's `execute` transaction
+   * commits. The keys of this record become the AK union — `ctx.invokeAsync`
+   * accepts only declared names. Supply explicit `<TArgs, TResult, S>` (or
+   * use `defineAITool`) to also type `ctx.store` / `ctx.load`.
+   *
+   * Constraints enforced by the runtime: one async call per execution, max
+   * chain length 10 hops, max delay 1 week.
+   *
+   * @see {@link https://github.com/JetBrains/youtrack/blob/main/docs/apps-workflows/async-functions.md}
+   */
+  asyncFunctions?: Record<
+    AK,
+    (ctx: AIToolAsyncFunctionContext<TSettings, TGlobalStorageExtensions, AK, S>) => void
+  >;
 }
 
 // =============================================================================
@@ -167,30 +317,54 @@ export interface AITool<
 // =============================================================================
 
 /**
- * Creates a type-safe AI tool with inferred argument types.
+ * Creates a type-safe AI tool with the async-functions surface narrowed.
+ * Two call shapes:
  *
- * Usage with json-schema-to-ts:
+ *   1. **`defineAITool<TArgs, TResult, S, AK>({...})`** — types arguments,
+ *      result, store schema, and async-function key union. `asyncFunctions`
+ *      is required and must implement every declared `AK` key.
+ *   2. **`withStore<TArgs, TResult, S>()({...})` curry from
+ *      `@jetbrains/youtrack-apps-tools`** — same coverage with `AK` inferred
+ *      from the `asyncFunctions` literal so the key union doesn't need to
+ *      be spelled out.
+ *
+ * Plain AI tools without async functions or a typed store keep using the
+ * `const aiTool: AITool<TArgs, TResult> = {...}` annotation pattern.
+ *
+ * @example
  * ```typescript
- * import { FromSchema } from 'json-schema-to-ts';
- *
- * const inputSchema = {
- *   type: 'object',
- *   properties: {
- *     query: { type: 'string' }
- *   },
- *   required: ['query']
- * } as const;
- *
- * type Args = FromSchema<typeof inputSchema>;
- *
- * export const aiTool = defineAITool<Args, Issue[]>({
- *   name: 'search_issues',
- *   description: 'Search issues',
- *   inputSchema,
+ * exports.aiTool = defineAITool<{ query: string }, string, { last: string }, 'onDone'>({
+ *   name: 'search_issues', description: 'Search issues',
  *   execute: (ctx) => {
- *     // ctx.arguments is typed as Args
- *     return search.search(null, ctx.arguments.query);
- *   }
+ *     ctx.store('last', ctx.arguments.query);
+ *     ctx.invokeAsync('onDone');
+ *     return 'ok';
+ *   },
+ *   asyncFunctions: { onDone: (ctx) => { console.log(ctx.load('last')); } }
+ * });
+ * ```
+ */
+export function defineAITool<
+  TArgs,
+  TResult,
+  S extends object,
+  AK extends string,
+  TSettings = AppTypeRegistry['settings'],
+  TGlobalStorageExtensions = AppTypeRegistry['appGlobalStorageExtensions']
+>(
+  tool: AITool<TArgs, TResult, TSettings, TGlobalStorageExtensions, AK, S>
+    & { asyncFunctions: Record<AK, (ctx: AIToolAsyncFunctionContext<TSettings, TGlobalStorageExtensions, AK, S>) => void> }
+): AITool<TArgs, TResult, TSettings, TGlobalStorageExtensions, AK, S>;
+
+/**
+ * Plain tool: types only the arguments and result. Use this shape when the
+ * tool has no `asyncFunctions` block and no typed store.
+ *
+ * @example
+ * ```typescript
+ * exports.aiTool = defineAITool<{ query: string }, Issue[]>({
+ *   name: 'search_issues', description: 'Search issues',
+ *   execute: (ctx) => search(ctx.arguments.query)
  * });
  * ```
  */

--- a/packages/youtrack-workflow-types/types/ai-tools.d.ts
+++ b/packages/youtrack-workflow-types/types/ai-tools.d.ts
@@ -19,7 +19,7 @@
  * @module @jetbrains/youtrack-scripting-api/ai-tools
  */
 
-import type { Issue, User, AppGlobalStorage } from './workflowTypeScriptStubs.js';
+import type { Issue, User, AppGlobalStorage, AsyncStoreValue } from './workflowTypeScriptStubs.js';
 import type { JSONSchema } from './utility-types.js';
 // Import HTTP Response type for use as the async HTTP response shape in
 // asyncFunctions called as `connection.*Async(..., 'handlerName')` callbacks.
@@ -99,7 +99,7 @@ export interface AIToolContext<
   TSettings = AppTypeRegistry['settings'],
   TGlobalStorageExtensions = AppTypeRegistry['appGlobalStorageExtensions'],
   AK extends string = string,
-  S extends object = Record<string, any>
+  S extends Record<keyof S, AsyncStoreValue> = Record<string, any>
 > {
   /**
    * Input arguments parsed according to inputSchema.
@@ -166,7 +166,7 @@ export interface AIToolAsyncFunctionContext<
   TSettings = AppTypeRegistry['settings'],
   TGlobalStorageExtensions = AppTypeRegistry['appGlobalStorageExtensions'],
   AK extends string = string,
-  S extends object = Record<string, any>
+  S extends Record<keyof S, AsyncStoreValue> = Record<string, any>
 > {
   /**
    * Current user under which the async function executes — captured at
@@ -252,7 +252,7 @@ export interface AITool<
   TSettings = AppTypeRegistry['settings'],
   TGlobalStorageExtensions = AppTypeRegistry['appGlobalStorageExtensions'],
   AK extends string = string,
-  S extends object = Record<string, any>
+  S extends Record<keyof S, AsyncStoreValue> = Record<string, any>
 > {
   /**
    * Unique name for the tool (used by AI to invoke it).
@@ -298,8 +298,8 @@ export interface AITool<
   /**
    * Named async functions invoked after the tool's `execute` transaction
    * commits. The keys of this record become the AK union — `ctx.invokeAsync`
-   * accepts only declared names. Supply explicit `<TArgs, TResult, S>` (or
-   * use `defineAITool`) to also type `ctx.store` / `ctx.load`.
+   * accepts only declared names. Use the `withStore<TArgs, TResult, S>()` curry
+   * from `@jetbrains/youtrack-apps-tools` to also type `ctx.store` / `ctx.load`.
    *
    * Constraints enforced by the runtime: one async call per execution, max
    * chain length 10 hops, max delay 1 week.
@@ -313,27 +313,25 @@ export interface AITool<
 }
 
 // =============================================================================
-// Type-Safe AI Tool Factory
+// Authoring a Type-Safe AI Tool
 // =============================================================================
 
 /**
- * Creates a type-safe AI tool with the async-functions surface narrowed.
- * Two call shapes:
+ * This module is type-only — there is no runtime factory to call. Author an
+ * AI tool with one of these patterns:
  *
- *   1. **`defineAITool<TArgs, TResult, S, AK>({...})`** — types arguments,
- *      result, store schema, and async-function key union. `asyncFunctions`
- *      is required and must implement every declared `AK` key.
- *   2. **`withStore<TArgs, TResult, S>()({...})` curry from
- *      `@jetbrains/youtrack-apps-tools`** — same coverage with `AK` inferred
- *      from the `asyncFunctions` literal so the key union doesn't need to
- *      be spelled out.
- *
- * Plain AI tools without async functions or a typed store keep using the
- * `const aiTool: AITool<TArgs, TResult> = {...}` annotation pattern.
+ *   1. **Plain tool** — annotate or `satisfies` to type arguments + result:
+ *      `const aiTool = {...} satisfies AITool<{ query: string }, Issue[]>;`
+ *   2. **Async / typed store** — the `withStore<TArgs, TResult, S>()({...})`
+ *      curry from `@jetbrains/youtrack-apps-tools` (a runtime identity helper).
+ *      It types `ctx.store` / `ctx.load` against `S` and infers the `AK` union
+ *      from the `asyncFunctions` literal.
  *
  * @example
  * ```typescript
- * exports.aiTool = defineAITool<{ query: string }, string, { last: string }, 'onDone'>({
+ * import { withStore } from '@jetbrains/youtrack-apps-tools/dx/runtime';
+ *
+ * exports.aiTool = withStore<{ query: string }, string, { last: string }>()({
  *   name: 'search_issues', description: 'Search issues',
  *   execute: (ctx) => {
  *     ctx.store('last', ctx.arguments.query);
@@ -344,33 +342,6 @@ export interface AITool<
  * });
  * ```
  */
-export function defineAITool<
-  TArgs,
-  TResult,
-  S extends object,
-  AK extends string,
-  TSettings = AppTypeRegistry['settings'],
-  TGlobalStorageExtensions = AppTypeRegistry['appGlobalStorageExtensions']
->(
-  tool: AITool<TArgs, TResult, TSettings, TGlobalStorageExtensions, AK, S>
-    & { asyncFunctions: Record<AK, (ctx: AIToolAsyncFunctionContext<TSettings, TGlobalStorageExtensions, AK, S>) => void> }
-): AITool<TArgs, TResult, TSettings, TGlobalStorageExtensions, AK, S>;
-
-/**
- * Plain tool: types only the arguments and result. Use this shape when the
- * tool has no `asyncFunctions` block and no typed store.
- *
- * @example
- * ```typescript
- * exports.aiTool = defineAITool<{ query: string }, Issue[]>({
- *   name: 'search_issues', description: 'Search issues',
- *   execute: (ctx) => search(ctx.arguments.query)
- * });
- * ```
- */
-export function defineAITool<TArgs = Record<string, unknown>, TResult = unknown>(
-  tool: AITool<TArgs, TResult>
-): AITool<TArgs, TResult>;
 
 // =============================================================================
 // Common AI Tool Patterns

--- a/packages/youtrack-workflow-types/types/apps.d.ts
+++ b/packages/youtrack-workflow-types/types/apps.d.ts
@@ -20,7 +20,7 @@
  */
 
 // Import entity types from the main workflow stubs file
-import type { Issue, Project, User, UserGroup, Article, AppGlobalStorage } from './workflowTypeScriptStubs.js';
+import type { Issue, Project, User, UserGroup, Article, AppGlobalStorage, AsyncStoreValue } from './workflowTypeScriptStubs.js';
 // Import HTTP Response type for use as the async HTTP response shape in
 // asyncFunctions called as `connection.*Async(..., 'handlerName')` callbacks.
 import type { Response } from './http.js';
@@ -235,7 +235,7 @@ export interface HttpResponse<TResponseBody = unknown> {
  *   get strict typing.
  * @template AK - Union of asyncFunctions key names declared on the parent
  *   handler. Inferred from the handler's `asyncFunctions` literal when
- *   constructed via `defineHttpHandler` or with `satisfies HttpHandler<S>`.
+ *   constructed via the `withStore<S>()` curry or with `satisfies HttpHandler<S>`.
  * @template TSettings - Type of app settings. Defaults to AppTypeRegistry['settings'].
  * @template TRequestBody - Type of the request body. Defaults to unknown.
  * @template TResponseBody - Type of the response body. Defaults to unknown.
@@ -249,7 +249,7 @@ export interface BaseHttpContext<
   TQueryParams = unknown,
   TGlobalStorageExtensions = AppTypeRegistry['appGlobalStorageExtensions'],
   AK extends string = string,
-  S extends object = Record<string, any>
+  S extends Record<keyof S, AsyncStoreValue> = Record<string, any>
 > {
   /**
    * The HTTP request object with typed body and query params.
@@ -328,7 +328,7 @@ export interface HttpAsyncFunctionContext<
   TUserExtensions = AppTypeRegistry['userExtensions'],
   TGlobalStorageExtensions = AppTypeRegistry['appGlobalStorageExtensions'],
   AK extends string = string,
-  S extends object = Record<string, any>
+  S extends Record<keyof S, AsyncStoreValue> = Record<string, any>
 > {
   /**
    * The currently authenticated user (the user under which the async function
@@ -420,7 +420,7 @@ export interface ProjectHttpContext<
   TResponseBody = unknown,
   TQueryParams = unknown,
   AK extends string = string,
-  S extends object = Record<string, any>
+  S extends Record<keyof S, AsyncStoreValue> = Record<string, any>
 > extends BaseHttpContext<TSettings, TRequestBody, TResponseBody, TQueryParams, AppTypeRegistry['appGlobalStorageExtensions'], AK, S> {
   /**
    * The project in context with typed extension properties.
@@ -447,7 +447,7 @@ export interface IssueHttpContext<
   TResponseBody = unknown,
   TQueryParams = unknown,
   AK extends string = string,
-  S extends object = Record<string, any>
+  S extends Record<keyof S, AsyncStoreValue> = Record<string, any>
 > extends ProjectHttpContext<TSettings, TProjectExtensions, TRequestBody, TResponseBody, TQueryParams, AK, S> {
   /**
    * The issue in context with typed extension properties.
@@ -467,7 +467,7 @@ export type HttpHandlerContext<
   TResponseBody = unknown,
   TQueryParams = unknown,
   AK extends string = string,
-  S extends object = Record<string, any>
+  S extends Record<keyof S, AsyncStoreValue> = Record<string, any>
 > = BaseHttpContext<TSettings, TRequestBody, TResponseBody, TQueryParams, AppTypeRegistry['appGlobalStorageExtensions'], AK, S>
   | ProjectHttpContext<TSettings, TProjectExtensions, TRequestBody, TResponseBody, TQueryParams, AK, S>
   | IssueHttpContext<TSettings, TIssueExtensions, TProjectExtensions, TRequestBody, TResponseBody, TQueryParams, AK, S>;
@@ -493,7 +493,7 @@ export interface HttpEndpoint<
   TResponseBody = unknown,
   TQueryParams = unknown,
   AK extends string = string,
-  S extends object = Record<string, any>
+  S extends Record<keyof S, AsyncStoreValue> = Record<string, any>
 > {
   /**
    * HTTP method for this endpoint.
@@ -542,7 +542,7 @@ export interface HttpHandler<
   TUserExtensions = AppTypeRegistry['userExtensions'],
   TGlobalStorageExtensions = AppTypeRegistry['appGlobalStorageExtensions'],
   AK extends string = string,
-  S extends object = Record<string, any>
+  S extends Record<keyof S, AsyncStoreValue> = Record<string, any>
 > {
   /**
    * Array of endpoint definitions. AK and S generics are propagated into each
@@ -562,8 +562,8 @@ export interface HttpHandler<
    *   to receive the HTTP response on `ctx.response`.
    *
    * The keys of this record become the AK union — `ctx.invokeAsync(name)`
-   * accepts only declared names. Supply explicit `<S>` (or use
-   * `defineHttpHandler`) to also type `ctx.store` / `ctx.load`.
+   * accepts only declared names. Use the `withStore<S>()` curry from
+   * `@jetbrains/youtrack-apps-tools` to also type `ctx.store` / `ctx.load`.
    *
    * Constraints enforced by the runtime: one async call per execution, max
    * chain length 10 hops, max delay 1 week.
@@ -577,25 +577,21 @@ export interface HttpHandler<
 }
 
 /**
- * Helper factory for constructing a typed `HttpHandler` with the async-
- * functions surface narrowed. Two call shapes:
+ * Authoring a typed `HttpHandler`. This module is type-only — there is no
+ * runtime factory to call. Use one of these patterns:
  *
- *   1. **`defineHttpHandler<S, AK>({...})`** — types `ctx.store` / `ctx.load`
- *      against `S` and narrows `ctx.invokeAsync` to the `AK` union.
- *      `asyncFunctions` is required and must implement every declared `AK`
- *      key. Use when the key union is known up front.
- *   2. **`withStore<S>()({...})` curry from `@jetbrains/youtrack-apps-tools`**
- *      — same narrowings with `AK` inferred from the `asyncFunctions`
- *      literal so the key union doesn't need to be spelled out.
- *
- * Plain handlers without async functions or a typed store keep using the
- * `const httpHandler: HttpHandler<...> = {...}` annotation pattern.
+ *   1. **Plain handler** — annotate or `satisfies`:
+ *      `const httpHandler = {...} satisfies HttpHandler<TSettings>;`
+ *   2. **Async / typed store** — the `withStore<S>()({...})` curry from
+ *      `@jetbrains/youtrack-apps-tools` (a runtime identity helper). It types
+ *      `ctx.store` / `ctx.load` against `S` and infers the `AK` union from the
+ *      `asyncFunctions` literal, so the key union doesn't need to be spelled out.
  *
  * @example
  * ```typescript
- * import { defineHttpHandler } from '@jetbrains/youtrack-scripting-api/apps';
+ * import { withStore } from '@jetbrains/youtrack-apps-tools/dx/runtime';
  *
- * exports.httpHandler = defineHttpHandler<{ count: number }, 'onTick'>({
+ * exports.httpHandler = withStore<{ count: number }>()({
  *   endpoints: [{
  *     scope: 'global', method: 'POST', path: '/tick',
  *     handle: (ctx) => {
@@ -608,19 +604,6 @@ export interface HttpHandler<
  * });
  * ```
  */
-export function defineHttpHandler<
-  S extends object,
-  AK extends string,
-  TSettings = AppTypeRegistry['settings'],
-  TIssueExtensions = AppTypeRegistry['issueExtensions'],
-  TProjectExtensions = AppTypeRegistry['projectExtensions'],
-  TArticleExtensions = AppTypeRegistry['articleExtensions'],
-  TUserExtensions = AppTypeRegistry['userExtensions'],
-  TGlobalStorageExtensions = AppTypeRegistry['appGlobalStorageExtensions']
->(
-  handler: HttpHandler<TSettings, TIssueExtensions, TProjectExtensions, TArticleExtensions, TUserExtensions, TGlobalStorageExtensions, AK, S>
-    & { asyncFunctions: Record<AK, (ctx: HttpAsyncFunctionContext<TSettings, TIssueExtensions, TProjectExtensions, TArticleExtensions, TUserExtensions, TGlobalStorageExtensions, AK, S>) => void> }
-): HttpHandler<TSettings, TIssueExtensions, TProjectExtensions, TArticleExtensions, TUserExtensions, TGlobalStorageExtensions, AK, S>;
 
 // =============================================================================
 // File-Based Routing Handler Types

--- a/packages/youtrack-workflow-types/types/apps.d.ts
+++ b/packages/youtrack-workflow-types/types/apps.d.ts
@@ -20,7 +20,10 @@
  */
 
 // Import entity types from the main workflow stubs file
-import type { Issue, Project, User, UserGroup, Article } from './workflowTypeScriptStubs.js';
+import type { Issue, Project, User, UserGroup, Article, AppGlobalStorage } from './workflowTypeScriptStubs.js';
+// Import HTTP Response type for use as the async HTTP response shape in
+// asyncFunctions called as `connection.*Async(..., 'handlerName')` callbacks.
+import type { Response } from './http.js';
 
 // =============================================================================
 // App Type Registry (Module Augmentation Pattern)
@@ -221,18 +224,32 @@ export interface HttpResponse<TResponseBody = unknown> {
 
 /**
  * Base context available to all HTTP handlers.
- * Uses AppTypeRegistry for default settings type - augment the registry for app-specific types.
  *
+ * Carries the AK / S generics so the inner `invokeAsync` / `store` / `load`
+ * methods are typed against the parent handler's `asyncFunctions` keys and
+ * store schema.
+ *
+ * @template S - Optional store schema for ctx.store / ctx.load. Defaults to
+ *   `Record<string, any>` (loose mode — any key/value accepted, ctx.load
+ *   returns `any | undefined`). Supply explicitly via `HttpHandler<S>` to
+ *   get strict typing.
+ * @template AK - Union of asyncFunctions key names declared on the parent
+ *   handler. Inferred from the handler's `asyncFunctions` literal when
+ *   constructed via `defineHttpHandler` or with `satisfies HttpHandler<S>`.
  * @template TSettings - Type of app settings. Defaults to AppTypeRegistry['settings'].
  * @template TRequestBody - Type of the request body. Defaults to unknown.
  * @template TResponseBody - Type of the response body. Defaults to unknown.
  * @template TQueryParams - Type of query parameters. Defaults to unknown.
+ * @template TGlobalStorageExtensions - Type of AppGlobalStorage extension properties.
  */
 export interface BaseHttpContext<
   TSettings = AppTypeRegistry['settings'],
   TRequestBody = unknown,
   TResponseBody = unknown,
-  TQueryParams = unknown
+  TQueryParams = unknown,
+  TGlobalStorageExtensions = AppTypeRegistry['appGlobalStorageExtensions'],
+  AK extends string = string,
+  S extends object = Record<string, any>
 > {
   /**
    * The HTTP request object with typed body and query params.
@@ -254,6 +271,136 @@ export interface BaseHttpContext<
    * Type is inferred from AppTypeRegistry['settings'] or explicit TSettings.
    */
   readonly settings: TSettings;
+
+  /**
+   * The app-level global storage entity. Use
+   * `ctx.globalStorage.extensionProperties.X` to read/write app-global
+   * values defined in the app's `entity-extensions.json`.
+   */
+  readonly globalStorage: AppGlobalStorage & { extensionProperties: TGlobalStorageExtensions };
+
+  /**
+   * Schedules an async function for execution after the current transaction
+   * commits. The async function must be declared in the handler's
+   * `asyncFunctions` block — `functionName` is constrained to the AK union.
+   *
+   * @param functionName Name of a function declared in `asyncFunctions`.
+   * @param delay Optional delay in milliseconds (default 0, max 7 days).
+   * @param deduplicationKey Optional key; a previously scheduled call with the
+   *   same key and handler-project combination is replaced, enabling debounce
+   *   patterns.
+   */
+  invokeAsync(functionName: AK, delay?: number, deduplicationKey?: string): void;
+
+  /**
+   * Persists a value across async boundaries. When a store schema `S` is
+   * supplied, the key must be a member of `keyof S` and the value must match
+   * `S[K]`. Retrieve later with `ctx.load(key)`.
+   */
+  store<K extends keyof S>(key: K, value: S[K]): void;
+
+  /**
+   * Retrieves a value previously stored with `ctx.store(key, value)`.
+   * Returns `S[K] | undefined` because a value may be absent at read time
+   * (never stored on this path, lost to a cross-execution race).
+   */
+  load<K extends keyof S>(key: K): S[K] | undefined;
+}
+
+/**
+ * Context passed to async functions declared in an HTTP handler's
+ * `asyncFunctions` block.
+ *
+ * Distinct from the sync `BaseHttpContext`: the function may be invoked via
+ * `ctx.invokeAsync('name', delay)` from a sync handler, or as the response
+ * callback of `connection.*Async(..., 'name')`. In the latter case `response`
+ * is populated with the incoming HTTP response from the remote server.
+ *
+ * Scope fields (`target`, `project`, `issue`) are optional because the same
+ * `asyncFunctions` block is shared across all endpoints of the handler — what
+ * is available depends on which endpoint scheduled the call.
+ */
+export interface HttpAsyncFunctionContext<
+  TSettings = AppTypeRegistry['settings'],
+  TIssueExtensions = AppTypeRegistry['issueExtensions'],
+  TProjectExtensions = AppTypeRegistry['projectExtensions'],
+  TArticleExtensions = AppTypeRegistry['articleExtensions'],
+  TUserExtensions = AppTypeRegistry['userExtensions'],
+  TGlobalStorageExtensions = AppTypeRegistry['appGlobalStorageExtensions'],
+  AK extends string = string,
+  S extends object = Record<string, any>
+> {
+  /**
+   * The currently authenticated user (the user under which the async function
+   * executes — captured at scheduling time).
+   */
+  readonly currentUser: User;
+
+  /**
+   * App settings as key-value pairs. Same type as the parent handler's
+   * sync context.
+   */
+  readonly settings: TSettings;
+
+  /**
+   * The app-level global storage entity. Use
+   * `ctx.globalStorage.extensionProperties.X` to read/write app-global
+   * values defined in the app's `entity-extensions.json`.
+   */
+  readonly globalStorage: AppGlobalStorage & { extensionProperties: TGlobalStorageExtensions };
+
+  /**
+   * The project in context, if the originating endpoint was project-, issue-,
+   * or article-scoped. `undefined` for global- and user-scoped endpoints.
+   */
+  readonly project?: Project & { extensionProperties: TProjectExtensions };
+
+  /**
+   * The issue in context, if the originating endpoint was issue-scoped.
+   * `undefined` otherwise.
+   */
+  readonly issue?: Issue & { extensionProperties: TIssueExtensions };
+
+  /**
+   * The article in context, if the originating endpoint was article-scoped.
+   * `undefined` otherwise.
+   */
+  readonly article?: Article & { extensionProperties: TArticleExtensions };
+
+  /**
+   * The user in context, if the originating endpoint was user-scoped.
+   * `undefined` otherwise.
+   */
+  readonly user?: User & { extensionProperties: TUserExtensions };
+
+  /**
+   * The HTTP response returned by the async HTTP call that triggered this
+   * function (e.g. `connection.postAsync(..., 'onResponse')`). `undefined`
+   * when the function was scheduled via `ctx.invokeAsync` rather than as an
+   * HTTP response callback.
+   *
+   * Body is truncated by the runtime at 1 MB.
+   */
+  readonly response?: Response;
+
+  /**
+   * Schedules another async function for execution. `functionName` is
+   * constrained to the AK union (the keys declared in the parent handler's
+   * `asyncFunctions`). Subject to the 10-hop max chain length.
+   */
+  invokeAsync(functionName: AK, delay?: number, deduplicationKey?: string): void;
+
+  /**
+   * Persists a value to be retrieved later with `ctx.load(key)` from a
+   * subsequent async function in the same chain. Typed against schema S.
+   */
+  store<K extends keyof S>(key: K, value: S[K]): void;
+
+  /**
+   * Retrieves a value stored earlier in the same async chain. Returns
+   * `S[K] | undefined` — narrow before use under strict null checks.
+   */
+  load<K extends keyof S>(key: K): S[K] | undefined;
 }
 
 /**
@@ -271,8 +418,10 @@ export interface ProjectHttpContext<
   TProjectExtensions = AppTypeRegistry['projectExtensions'],
   TRequestBody = unknown,
   TResponseBody = unknown,
-  TQueryParams = unknown
-> extends BaseHttpContext<TSettings, TRequestBody, TResponseBody, TQueryParams> {
+  TQueryParams = unknown,
+  AK extends string = string,
+  S extends object = Record<string, any>
+> extends BaseHttpContext<TSettings, TRequestBody, TResponseBody, TQueryParams, AppTypeRegistry['appGlobalStorageExtensions'], AK, S> {
   /**
    * The project in context with typed extension properties.
    */
@@ -296,8 +445,10 @@ export interface IssueHttpContext<
   TProjectExtensions = AppTypeRegistry['projectExtensions'],
   TRequestBody = unknown,
   TResponseBody = unknown,
-  TQueryParams = unknown
-> extends ProjectHttpContext<TSettings, TProjectExtensions, TRequestBody, TResponseBody, TQueryParams> {
+  TQueryParams = unknown,
+  AK extends string = string,
+  S extends object = Record<string, any>
+> extends ProjectHttpContext<TSettings, TProjectExtensions, TRequestBody, TResponseBody, TQueryParams, AK, S> {
   /**
    * The issue in context with typed extension properties.
    */
@@ -314,10 +465,12 @@ export type HttpHandlerContext<
   TProjectExtensions = AppTypeRegistry['projectExtensions'],
   TRequestBody = unknown,
   TResponseBody = unknown,
-  TQueryParams = unknown
-> = BaseHttpContext<TSettings, TRequestBody, TResponseBody, TQueryParams>
-  | ProjectHttpContext<TSettings, TProjectExtensions, TRequestBody, TResponseBody, TQueryParams>
-  | IssueHttpContext<TSettings, TIssueExtensions, TProjectExtensions, TRequestBody, TResponseBody, TQueryParams>;
+  TQueryParams = unknown,
+  AK extends string = string,
+  S extends object = Record<string, any>
+> = BaseHttpContext<TSettings, TRequestBody, TResponseBody, TQueryParams, AppTypeRegistry['appGlobalStorageExtensions'], AK, S>
+  | ProjectHttpContext<TSettings, TProjectExtensions, TRequestBody, TResponseBody, TQueryParams, AK, S>
+  | IssueHttpContext<TSettings, TIssueExtensions, TProjectExtensions, TRequestBody, TResponseBody, TQueryParams, AK, S>;
 
 /**
  * HTTP endpoint definition.
@@ -338,7 +491,9 @@ export interface HttpEndpoint<
   TProjectExtensions = AppTypeRegistry['projectExtensions'],
   TRequestBody = unknown,
   TResponseBody = unknown,
-  TQueryParams = unknown
+  TQueryParams = unknown,
+  AK extends string = string,
+  S extends object = Record<string, any>
 > {
   /**
    * HTTP method for this endpoint.
@@ -364,10 +519,10 @@ export interface HttpEndpoint<
    * The context is typed based on scope and includes typed request/response.
    */
   handle: (ctx: TScope extends 'issue'
-    ? IssueHttpContext<TSettings, TIssueExtensions, TProjectExtensions, TRequestBody, TResponseBody, TQueryParams>
+    ? IssueHttpContext<TSettings, TIssueExtensions, TProjectExtensions, TRequestBody, TResponseBody, TQueryParams, AK, S>
     : TScope extends 'project'
-      ? ProjectHttpContext<TSettings, TProjectExtensions, TRequestBody, TResponseBody, TQueryParams>
-      : BaseHttpContext<TSettings, TRequestBody, TResponseBody, TQueryParams>
+      ? ProjectHttpContext<TSettings, TProjectExtensions, TRequestBody, TResponseBody, TQueryParams, AK, S>
+      : BaseHttpContext<TSettings, TRequestBody, TResponseBody, TQueryParams, AppTypeRegistry['appGlobalStorageExtensions'], AK, S>
   ) => void | Promise<void>;
 }
 
@@ -382,13 +537,90 @@ export interface HttpEndpoint<
 export interface HttpHandler<
   TSettings = AppTypeRegistry['settings'],
   TIssueExtensions = AppTypeRegistry['issueExtensions'],
-  TProjectExtensions = AppTypeRegistry['projectExtensions']
+  TProjectExtensions = AppTypeRegistry['projectExtensions'],
+  TArticleExtensions = AppTypeRegistry['articleExtensions'],
+  TUserExtensions = AppTypeRegistry['userExtensions'],
+  TGlobalStorageExtensions = AppTypeRegistry['appGlobalStorageExtensions'],
+  AK extends string = string,
+  S extends object = Record<string, any>
 > {
   /**
-   * Array of endpoint definitions.
+   * Array of endpoint definitions. AK and S generics are propagated into each
+   * endpoint's `handle(ctx)` so `ctx.invokeAsync` / `ctx.store` / `ctx.load`
+   * are typed against the parent handler's `asyncFunctions` keys and
+   * store schema.
    */
-  endpoints: HttpEndpoint<HttpScope, TSettings, TIssueExtensions, TProjectExtensions>[];
+  endpoints: HttpEndpoint<HttpScope, TSettings, TIssueExtensions, TProjectExtensions, unknown, unknown, unknown, AK, S>[];
+
+  /**
+   * Named async functions invoked after the originating transaction commits,
+   * each in its own read-write transaction. Use cases:
+   *
+   * - Schedule by name from a sync endpoint handler via
+   *   `ctx.invokeAsync('functionName', delay)`.
+   * - Pass the function name as the last argument of `connection.*Async(...)`
+   *   to receive the HTTP response on `ctx.response`.
+   *
+   * The keys of this record become the AK union — `ctx.invokeAsync(name)`
+   * accepts only declared names. Supply explicit `<S>` (or use
+   * `defineHttpHandler`) to also type `ctx.store` / `ctx.load`.
+   *
+   * Constraints enforced by the runtime: one async call per execution, max
+   * chain length 10 hops, max delay 1 week.
+   *
+   * @see {@link https://github.com/JetBrains/youtrack/blob/main/docs/apps-workflows/async-functions.md}
+   */
+  asyncFunctions?: Record<
+    AK,
+    (ctx: HttpAsyncFunctionContext<TSettings, TIssueExtensions, TProjectExtensions, TArticleExtensions, TUserExtensions, TGlobalStorageExtensions, AK, S>) => void
+  >;
 }
+
+/**
+ * Helper factory for constructing a typed `HttpHandler` with the async-
+ * functions surface narrowed. Two call shapes:
+ *
+ *   1. **`defineHttpHandler<S, AK>({...})`** — types `ctx.store` / `ctx.load`
+ *      against `S` and narrows `ctx.invokeAsync` to the `AK` union.
+ *      `asyncFunctions` is required and must implement every declared `AK`
+ *      key. Use when the key union is known up front.
+ *   2. **`withStore<S>()({...})` curry from `@jetbrains/youtrack-apps-tools`**
+ *      — same narrowings with `AK` inferred from the `asyncFunctions`
+ *      literal so the key union doesn't need to be spelled out.
+ *
+ * Plain handlers without async functions or a typed store keep using the
+ * `const httpHandler: HttpHandler<...> = {...}` annotation pattern.
+ *
+ * @example
+ * ```typescript
+ * import { defineHttpHandler } from '@jetbrains/youtrack-scripting-api/apps';
+ *
+ * exports.httpHandler = defineHttpHandler<{ count: number }, 'onTick'>({
+ *   endpoints: [{
+ *     scope: 'global', method: 'POST', path: '/tick',
+ *     handle: (ctx) => {
+ *       ctx.store('count', 1);
+ *       ctx.invokeAsync('onTick');
+ *       ctx.response.json({});
+ *     }
+ *   }],
+ *   asyncFunctions: { onTick: (ctx) => { console.log(ctx.load('count')); } }
+ * });
+ * ```
+ */
+export function defineHttpHandler<
+  S extends object,
+  AK extends string,
+  TSettings = AppTypeRegistry['settings'],
+  TIssueExtensions = AppTypeRegistry['issueExtensions'],
+  TProjectExtensions = AppTypeRegistry['projectExtensions'],
+  TArticleExtensions = AppTypeRegistry['articleExtensions'],
+  TUserExtensions = AppTypeRegistry['userExtensions'],
+  TGlobalStorageExtensions = AppTypeRegistry['appGlobalStorageExtensions']
+>(
+  handler: HttpHandler<TSettings, TIssueExtensions, TProjectExtensions, TArticleExtensions, TUserExtensions, TGlobalStorageExtensions, AK, S>
+    & { asyncFunctions: Record<AK, (ctx: HttpAsyncFunctionContext<TSettings, TIssueExtensions, TProjectExtensions, TArticleExtensions, TUserExtensions, TGlobalStorageExtensions, AK, S>) => void> }
+): HttpHandler<TSettings, TIssueExtensions, TProjectExtensions, TArticleExtensions, TUserExtensions, TGlobalStorageExtensions, AK, S>;
 
 // =============================================================================
 // File-Based Routing Handler Types

--- a/packages/youtrack-workflow-types/types/http.d.ts
+++ b/packages/youtrack-workflow-types/types/http.d.ts
@@ -202,6 +202,84 @@ export class Connection {
    * @returns An object that represents an HTTP response.
    */
   optionsSync(uri?: string, queryParams?: Array<QueryParam> | Record<string, string | string[]>): Response;
+
+  /**
+   * Sends an asynchronous HTTP request. The request is executed after the current transaction
+   * commits; the response is delivered to the named async function as `ctx.response`.
+   * @param requestType A valid HTTP request type.
+   * @param uri A relative URI.
+   * @param queryParams The query parameters.
+   * @param payload The payload to be sent in the request.
+   * @param callbackFunctionName The name of a function declared in the rule's `asyncFunctions` block.
+   */
+  doAsync(requestType: string, uri: string | undefined, queryParams: Array<QueryParam> | Record<string, string | string[]> | null | undefined, payload: string | any | undefined, callbackFunctionName: string): void;
+
+  /**
+   * Executes an asynchronous GET request. The response is delivered to the named async function as `ctx.response`.
+   * @param uri The request URI.
+   * @param queryParams The query parameters.
+   * @param callbackFunctionName The name of a function declared in the rule's `asyncFunctions` block.
+   */
+  getAsync(uri: string | undefined, queryParams: Array<QueryParam> | Record<string, string | string[]> | null | undefined, callbackFunctionName: string): void;
+
+  /**
+   * Executes an asynchronous HEAD request. The response is delivered to the named async function as `ctx.response`.
+   * @param uri The request URI.
+   * @param queryParams The query parameters.
+   * @param callbackFunctionName The name of a function declared in the rule's `asyncFunctions` block.
+   */
+  headAsync(uri: string | undefined, queryParams: Array<QueryParam> | Record<string, string | string[]> | null | undefined, callbackFunctionName: string): void;
+
+  /**
+   * Executes an asynchronous POST request. The response is delivered to the named async function as `ctx.response`.
+   * @param uri The request URI.
+   * @param queryParams The query parameters.
+   * @param payload The payload to be sent in the request.
+   * @param callbackFunctionName The name of a function declared in the rule's `asyncFunctions` block.
+   */
+  postAsync(uri: string | undefined, queryParams: Array<QueryParam> | Record<string, string | string[]> | null | undefined, payload: string | any | undefined, callbackFunctionName: string): void;
+
+  /**
+   * Executes an asynchronous PUT request. The response is delivered to the named async function as `ctx.response`.
+   * @param uri The request URI.
+   * @param queryParams The query parameters.
+   * @param payload The payload to be sent in the request.
+   * @param callbackFunctionName The name of a function declared in the rule's `asyncFunctions` block.
+   */
+  putAsync(uri: string | undefined, queryParams: Array<QueryParam> | Record<string, string | string[]> | null | undefined, payload: string | undefined, callbackFunctionName: string): void;
+
+  /**
+   * Executes an asynchronous PATCH request. The response is delivered to the named async function as `ctx.response`.
+   * @param uri The request URI.
+   * @param queryParams The query parameters.
+   * @param payload The payload to be sent in the request.
+   * @param callbackFunctionName The name of a function declared in the rule's `asyncFunctions` block.
+   */
+  patchAsync(uri: string | undefined, queryParams: Array<QueryParam> | Record<string, string | string[]> | null | undefined, payload: string | undefined, callbackFunctionName: string): void;
+
+  /**
+   * Executes an asynchronous DELETE request. The response is delivered to the named async function as `ctx.response`.
+   * @param uri The request URI.
+   * @param queryParams The query parameters.
+   * @param callbackFunctionName The name of a function declared in the rule's `asyncFunctions` block.
+   */
+  deleteAsync(uri: string | undefined, queryParams: Array<QueryParam> | Record<string, string | string[]> | null | undefined, callbackFunctionName: string): void;
+
+  /**
+   * Executes an asynchronous CONNECT request. The response is delivered to the named async function as `ctx.response`.
+   * @param uri request URI.
+   * @param queryParams The query parameters.
+   * @param callbackFunctionName The name of a function declared in the rule's `asyncFunctions` block.
+   */
+  connectAsync(uri: string | undefined, queryParams: Array<QueryParam> | Record<string, string | string[]> | null | undefined, callbackFunctionName: string): void;
+
+  /**
+   * Executes an asynchronous OPTIONS request. The response is delivered to the named async function as `ctx.response`.
+   * @param uri request URI.
+   * @param queryParams The query parameters.
+   * @param callbackFunctionName The name of a function declared in the rule's `asyncFunctions` block.
+   */
+  optionsAsync(uri: string | undefined, queryParams: Array<QueryParam> | Record<string, string | string[]> | null | undefined, callbackFunctionName: string): void;
 }
 
 /**

--- a/packages/youtrack-workflow-types/types/workflowTypeScriptStubs.d.ts
+++ b/packages/youtrack-workflow-types/types/workflowTypeScriptStubs.d.ts
@@ -314,6 +314,15 @@ export interface UserInputSpec {
 }
 
 /**
+ * Values that survive an async-store round-trip (`ctx.store` -> `ctx.load`).
+ * The runtime (`AbstractScriptingContext.storeAsync`/`loadAsync`) only preserves
+ * primitives and entity references; any other object is coerced via `toString()`
+ * and would load back as a string. Store schemas are constrained to these so the
+ * type system never promises an object the runtime cannot return.
+ */
+export type AsyncStoreValue = string | number | boolean | null | BaseEntity;
+
+/**
  * Base execution context for action functions (without requirements).
  * Generic parameter AK is the union of async function names declared in the rule's
  * `asyncFunctions` block; it constrains `invokeAsync` to those names.
@@ -321,7 +330,7 @@ export interface UserInputSpec {
  * `ctx.store` and `ctx.load`. Defaults to a permissive map, so without an explicit
  * schema both methods stay loosely typed.
  */
-export interface BaseActionContext<AK extends PropertyKey = string, S extends Record<string, unknown> = Record<string, any>> {
+export interface BaseActionContext<AK extends PropertyKey = string, S extends Record<keyof S, AsyncStoreValue> = Record<string, any>> {
   /** The current issue (for Issue rules). */
   issue: Issue;
   /** The current article (for Article rules). */
@@ -418,7 +427,7 @@ export type IssueWithRequirements<R extends Record<string, Requirement>> =
  * // Context will have: ctx.Priority['Show-stopper']
  * // And ctx.issue.fields.Priority with proper type
  */
-export type ActionContext<R extends Record<string, Requirement> = Record<string, Requirement>, AK extends PropertyKey = string, S extends Record<string, unknown> = Record<string, any>> =
+export type ActionContext<R extends Record<string, Requirement> = Record<string, Requirement>, AK extends PropertyKey = string, S extends Record<keyof S, AsyncStoreValue> = Record<string, any>> =
   Omit<BaseActionContext<AK, S>, 'issue'> & {
     issue: IssueWithRequirements<R>
   } & RequirementsContext<R>;
@@ -431,7 +440,7 @@ export type ActionContext<R extends Record<string, Requirement> = Record<string,
  * The synchronous `action` never receives a response, so it stays off
  * {@link ActionContext}.
  */
-export type AsyncActionContext<R extends Record<string, Requirement> = Record<string, Requirement>, AK extends PropertyKey = string, S extends Record<string, unknown> = Record<string, any>> =
+export type AsyncActionContext<R extends Record<string, Requirement> = Record<string, Requirement>, AK extends PropertyKey = string, S extends Record<keyof S, AsyncStoreValue> = Record<string, any>> =
   ActionContext<R, AK, S> & {
     /**
      * The incoming HTTP response for async HTTP-response callbacks.
@@ -482,7 +491,7 @@ export type GuardFunction<R extends Record<string, Requirement> = Record<string,
  *   }
  * });
  */
-export interface RuleProperties<R extends Record<string, Requirement> = Record<string, Requirement>, AK extends string = string, S extends Record<string, unknown> = Record<string, any>> {
+export interface RuleProperties<R extends Record<string, Requirement> = Record<string, Requirement>, AK extends string = string, S extends Record<keyof S, AsyncStoreValue> = Record<string, any>> {
   /** Title of the rule */
   title?: string;
   /** Command that triggers the rule */
@@ -1171,7 +1180,7 @@ export declare class Article extends BaseArticle {
    * @param ruleProperties $ignore
    * @returns The object representation of the rule.
    */
-  static action<S extends Record<string, unknown> = Record<string, any>, R extends Requirements = Requirements, AK extends string = string>(ruleProperties?: RuleProperties<R, AK, S>): RuleProperties<R, AK, S>;
+  static action<R extends Requirements = Requirements, AK extends string = string, S extends Record<keyof S, AsyncStoreValue> = Record<string, any>>(ruleProperties?: RuleProperties<R, AK, S>): RuleProperties<R, AK, S>;
 
   /**
    * Creates a new article draft.
@@ -1223,7 +1232,7 @@ export declare class Article extends BaseArticle {
    * @param ruleProperties $ignore
    * @returns The object representation of the rule.
    */
-  static onChange<S extends Record<string, unknown> = Record<string, any>, R extends Requirements = Requirements, AK extends string = string>(ruleProperties?: RuleProperties<R, AK, S>): RuleProperties<R, AK, S>;
+  static onChange<R extends Requirements = Requirements, AK extends string = string, S extends Record<keyof S, AsyncStoreValue> = Record<string, any>>(ruleProperties?: RuleProperties<R, AK, S>): RuleProperties<R, AK, S>;
 
   /**
    * Attaches a file to the article.
@@ -1297,7 +1306,7 @@ export declare class ArticleAttachment extends BaseArticleAttachment {
    * @param ruleProperties $ignore
    * @returns The object representation of the rule.
    */
-  static action<S extends Record<string, unknown> = Record<string, any>, R extends Requirements = Requirements, AK extends string = string>(ruleProperties?: RuleProperties<R, AK, S>): RuleProperties<R, AK, S>;
+  static action<R extends Requirements = Requirements, AK extends string = string, S extends Record<keyof S, AsyncStoreValue> = Record<string, any>>(ruleProperties?: RuleProperties<R, AK, S>): RuleProperties<R, AK, S>;
 
   /**
    * Searches for ArticleAttachment entities with extension properties that match the specified query.
@@ -1369,7 +1378,7 @@ export declare class ArticleComment extends BaseArticleComment {
    * @param ruleProperties $ignore
    * @returns The object representation of the rule.
    */
-  static action<S extends Record<string, unknown> = Record<string, any>, R extends Requirements = Requirements, AK extends string = string>(ruleProperties?: RuleProperties<R, AK, S>): RuleProperties<R, AK, S>;
+  static action<R extends Requirements = Requirements, AK extends string = string, S extends Record<keyof S, AsyncStoreValue> = Record<string, any>>(ruleProperties?: RuleProperties<R, AK, S>): RuleProperties<R, AK, S>;
 
   /**
    * Searches for ArticleComment entities with extension properties that match the specified query.
@@ -2516,7 +2525,7 @@ export declare class Issue extends BaseEntity {
    * @param ruleProperties $ignore
    * @returns The object representation of the rule.
    */
-  static action<S extends Record<string, unknown> = Record<string, any>, R extends Requirements = Requirements, AK extends string = string>(ruleProperties?: RuleProperties<R, AK, S>): RuleProperties<R, AK, S>;
+  static action<R extends Requirements = Requirements, AK extends string = string, S extends Record<keyof S, AsyncStoreValue> = Record<string, any>>(ruleProperties?: RuleProperties<R, AK, S>): RuleProperties<R, AK, S>;
 
   /**
    * Creates a new issue draft.
@@ -2579,7 +2588,7 @@ export declare class Issue extends BaseEntity {
    * @param ruleProperties $ignore
    * @returns The object representation of the rule.
    */
-  static onChange<S extends Record<string, unknown> = Record<string, any>, R extends Requirements = Requirements, AK extends string = string>(ruleProperties?: RuleProperties<R, AK, S>): RuleProperties<R, AK, S>;
+  static onChange<R extends Requirements = Requirements, AK extends string = string, S extends Record<keyof S, AsyncStoreValue> = Record<string, any>>(ruleProperties?: RuleProperties<R, AK, S>): RuleProperties<R, AK, S>;
 
   /**
    * Creates a declaration of a rule that is triggered on a set schedule.
@@ -2606,7 +2615,7 @@ export declare class Issue extends BaseEntity {
    * @param ruleProperties $ignore
    * @returns The object representation of the rule.
    */
-  static onSchedule<S extends Record<string, unknown> = Record<string, any>, R extends Requirements = Requirements, AK extends string = string>(ruleProperties?: RuleProperties<R, AK, S>): RuleProperties<R, AK, S>;
+  static onSchedule<R extends Requirements = Requirements, AK extends string = string, S extends Record<keyof S, AsyncStoreValue> = Record<string, any>>(ruleProperties?: RuleProperties<R, AK, S>): RuleProperties<R, AK, S>;
 
   /**
    * Creates a declaration of a custom SLA policy. An SLA policy defines the time goals for the replies from staff and request resolution.
@@ -2649,7 +2658,7 @@ export declare class Issue extends BaseEntity {
    * @param ruleProperties $ignore
    * @returns The object representation of the SLA policy.
    */
-  static sla<S extends Record<string, unknown> = Record<string, any>, R extends Requirements = Requirements, AK extends string = string>(ruleProperties?: RuleProperties<R, AK, S>): RuleProperties<R, AK, S>;
+  static sla<R extends Requirements = Requirements, AK extends string = string, S extends Record<keyof S, AsyncStoreValue> = Record<string, any>>(ruleProperties?: RuleProperties<R, AK, S>): RuleProperties<R, AK, S>;
 
   /**
    * Creates a declaration of a state-machine rule. The state-machine imposes restrictions for the transitions between values in a custom field.
@@ -2706,7 +2715,7 @@ export declare class Issue extends BaseEntity {
    * @param ruleProperties $ignore
    * @returns The object representation of the rule.
    */
-  static stateMachine<S extends Record<string, unknown> = Record<string, any>, R extends Requirements = Requirements, AK extends string = string>(ruleProperties?: RuleProperties<R, AK, S>): RuleProperties<R, AK, S>;
+  static stateMachine<R extends Requirements = Requirements, AK extends string = string, S extends Record<keyof S, AsyncStoreValue> = Record<string, any>>(ruleProperties?: RuleProperties<R, AK, S>): RuleProperties<R, AK, S>;
 
   /**
    * Attaches a file to the issue.
@@ -2951,7 +2960,7 @@ export declare class IssueAttachment extends PersistentFile {
    * @param ruleProperties $ignore
    * @returns The object representation of the rule.
    */
-  static action<S extends Record<string, unknown> = Record<string, any>, R extends Requirements = Requirements, AK extends string = string>(ruleProperties?: RuleProperties<R, AK, S>): RuleProperties<R, AK, S>;
+  static action<R extends Requirements = Requirements, AK extends string = string, S extends Record<keyof S, AsyncStoreValue> = Record<string, any>>(ruleProperties?: RuleProperties<R, AK, S>): RuleProperties<R, AK, S>;
 
   /**
    * Searches for IssueAttachment entities with extension properties that match the specified query.
@@ -3071,7 +3080,7 @@ export declare class IssueComment extends BaseComment {
    * @param ruleProperties $ignore
    * @returns The object representation of the rule.
    */
-  static action<S extends Record<string, unknown> = Record<string, any>, R extends Requirements = Requirements, AK extends string = string>(ruleProperties?: RuleProperties<R, AK, S>): RuleProperties<R, AK, S>;
+  static action<R extends Requirements = Requirements, AK extends string = string, S extends Record<keyof S, AsyncStoreValue> = Record<string, any>>(ruleProperties?: RuleProperties<R, AK, S>): RuleProperties<R, AK, S>;
 
   /**
    * Searches for IssueComment entities with extension properties that match the specified query.

--- a/packages/youtrack-workflow-types/types/workflowTypeScriptStubs.d.ts
+++ b/packages/youtrack-workflow-types/types/workflowTypeScriptStubs.d.ts
@@ -315,8 +315,13 @@ export interface UserInputSpec {
 
 /**
  * Base execution context for action functions (without requirements).
+ * Generic parameter AK is the union of async function names declared in the rule's
+ * `asyncFunctions` block; it constrains `invokeAsync` to those names.
+ * Generic parameter S is the optional store schema (key -> value type) that types
+ * `ctx.store` and `ctx.load`. Defaults to a permissive map, so without an explicit
+ * schema both methods stay loosely typed.
  */
-export interface BaseActionContext {
+export interface BaseActionContext<AK extends PropertyKey = string, S extends Record<string, unknown> = Record<string, any>> {
   /** The current issue (for Issue rules). */
   issue: Issue;
   /** The current article (for Article rules). */
@@ -345,6 +350,30 @@ export interface BaseActionContext {
    * Use the app-types-generator to get fully typed settings.
    */
   settings?: Record<string, any>;
+  /**
+   * Schedules an async function for execution after the current transaction commits.
+   * The async function must be declared in the `asyncFunctions` block of the rule or AI tool.
+   * @param functionName The name of a function declared in `asyncFunctions`.
+   * @param delay Optional delay in milliseconds (default 0, max 7 days).
+   * @param deduplicationKey Optional key; a previously scheduled call with the same key and
+   * rule-project combination is replaced, enabling debounce patterns.
+   */
+  invokeAsync(functionName: AK, delay?: number, deduplicationKey?: string): void;
+  /**
+   * Persists a value across async boundaries. Retrieve it later with `ctx.load(key)`.
+   * The value can be a primitive, null, or an entity reference. Values are only persisted
+   * when an async function or async HTTP call is scheduled in the same execution.
+   * When a store schema is supplied, the key and value type are checked against it.
+   */
+  store<K extends keyof S>(key: K, value: S[K]): void;
+  /**
+   * Retrieves a value previously stored with `ctx.store(key, value)`, with entity references
+   * resolved back to their entity objects. Only available inside async functions.
+   * When a store schema is supplied, the return type is taken from it and unknown keys are rejected.
+   * The result is `| undefined` because a value may be absent at read time (never stored on this
+   * path, not persisted, or lost to a cross-execution race) - narrow it before use.
+   */
+  load<K extends keyof S>(key: K): S[K] | undefined;
 }
 
 /**
@@ -389,10 +418,29 @@ export type IssueWithRequirements<R extends Record<string, Requirement>> =
  * // Context will have: ctx.Priority['Show-stopper']
  * // And ctx.issue.fields.Priority with proper type
  */
-export type ActionContext<R extends Record<string, Requirement> = Record<string, Requirement>> =
-  Omit<BaseActionContext, 'issue'> & {
+export type ActionContext<R extends Record<string, Requirement> = Record<string, Requirement>, AK extends PropertyKey = string, S extends Record<string, unknown> = Record<string, any>> =
+  Omit<BaseActionContext<AK, S>, 'issue'> & {
     issue: IssueWithRequirements<R>
   } & RequirementsContext<R>;
+
+/**
+ * The execution context for functions declared in a rule's `asyncFunctions`
+ * block. Extends {@link ActionContext} with `response`, the incoming HTTP
+ * response that the runtime populates only when the function runs as an async
+ * HTTP-response callback (`connection.postAsync(uri, params, payload, 'name')`).
+ * The synchronous `action` never receives a response, so it stays off
+ * {@link ActionContext}.
+ */
+export type AsyncActionContext<R extends Record<string, Requirement> = Record<string, Requirement>, AK extends PropertyKey = string, S extends Record<string, unknown> = Record<string, any>> =
+  ActionContext<R, AK, S> & {
+    /**
+     * The incoming HTTP response for async HTTP-response callbacks.
+     * Properties: `isSuccess` (boolean), `body` (string), `code` (number),
+     * `headers` (object), `json()` (parses the body as JSON), and `exception`
+     * (string, if the request failed).
+     */
+    response?: any;
+  };
 
 /**
  * The execution context for guard functions.
@@ -434,15 +482,15 @@ export type GuardFunction<R extends Record<string, Requirement> = Record<string,
  *   }
  * });
  */
-export interface RuleProperties<R extends Record<string, Requirement> = Record<string, Requirement>> {
+export interface RuleProperties<R extends Record<string, Requirement> = Record<string, Requirement>, AK extends string = string, S extends Record<string, unknown> = Record<string, any>> {
   /** Title of the rule */
   title?: string;
   /** Command that triggers the rule */
   command?: string;
   /** Guard function with typed requirements context */
   guard?: GuardFunction<R>;
-  /** Action function with typed requirements context */
-  action?: ActionFunction<R>;
+  /** Action function with typed requirements context. `ctx.invokeAsync` accepts only names declared in `asyncFunctions`. */
+  action?: (ctx: ActionContext<R, AK, S>) => void;
   /** Requirements that get merged into the context */
   requirements?: Requirements<R>;
   /** Run on settings */
@@ -460,6 +508,13 @@ export interface RuleProperties<R extends Record<string, Requirement> = Record<s
   cron?: string;
   /** User input specification */
   userInput?: UserInputSpec;
+  /**
+   * A map of named functions that can be invoked asynchronously from the `action` function
+   * (via `ctx.invokeAsync`) or as HTTP response callbacks. Each function receives an
+   * {@link AsyncActionContext} — the same shape as `action` plus `ctx.response` for HTTP callbacks.
+   * The function names declared here are the only values accepted by `ctx.invokeAsync`.
+   */
+  asyncFunctions?: Record<AK, (ctx: AsyncActionContext<R, AK, S>) => void>;
   /** SLA-specific: onEnter function */
   onEnter?: ActionFunction<R>;
   /** SLA-specific: onBreach function */
@@ -675,7 +730,7 @@ export interface CommonIssueFields {
   /** Date field (ordinal 8). Stores timestamp as number. */
   'Due Date'?: number | null;
   /** Index signature for any other custom fields - includes optional Set methods for multi-value fields */
-  [fieldName: string]: DynamicFieldValue | Set<BaseEntity> | string | number | null | undefined;
+  [fieldName: string]: DynamicFieldValue | Set<BaseEntity> | BaseEntity | string | number | null | undefined;
 }
 
 /**
@@ -1116,13 +1171,13 @@ export declare class Article extends BaseArticle {
    * @param ruleProperties $ignore
    * @returns The object representation of the rule.
    */
-  static action<R extends Requirements = Requirements>(ruleProperties?: RuleProperties<R>): RuleProperties<R>;
+  static action<S extends Record<string, unknown> = Record<string, any>, R extends Requirements = Requirements, AK extends string = string>(ruleProperties?: RuleProperties<R, AK, S>): RuleProperties<R, AK, S>;
 
   /**
    * Creates a new article draft.
-   * @param project The project where the new article is created.
-   * @param author The author of the article.
-   * @returns Newly created article draft.
+   * @param project The project where the new article draft is created.
+   * @param author The author of the article draft.
+   * @returns The newly created article draft.
    */
   static createDraft(project?: Project, author?: User): BaseArticle;
 
@@ -1168,7 +1223,7 @@ export declare class Article extends BaseArticle {
    * @param ruleProperties $ignore
    * @returns The object representation of the rule.
    */
-  static onChange<R extends Requirements = Requirements>(ruleProperties?: RuleProperties<R>): RuleProperties<R>;
+  static onChange<S extends Record<string, unknown> = Record<string, any>, R extends Requirements = Requirements, AK extends string = string>(ruleProperties?: RuleProperties<R, AK, S>): RuleProperties<R, AK, S>;
 
   /**
    * Attaches a file to the article.
@@ -1242,7 +1297,7 @@ export declare class ArticleAttachment extends BaseArticleAttachment {
    * @param ruleProperties $ignore
    * @returns The object representation of the rule.
    */
-  static action<R extends Requirements = Requirements>(ruleProperties?: RuleProperties<R>): RuleProperties<R>;
+  static action<S extends Record<string, unknown> = Record<string, any>, R extends Requirements = Requirements, AK extends string = string>(ruleProperties?: RuleProperties<R, AK, S>): RuleProperties<R, AK, S>;
 
   /**
    * Searches for ArticleAttachment entities with extension properties that match the specified query.
@@ -1314,7 +1369,7 @@ export declare class ArticleComment extends BaseArticleComment {
    * @param ruleProperties $ignore
    * @returns The object representation of the rule.
    */
-  static action<R extends Requirements = Requirements>(ruleProperties?: RuleProperties<R>): RuleProperties<R>;
+  static action<S extends Record<string, unknown> = Record<string, any>, R extends Requirements = Requirements, AK extends string = string>(ruleProperties?: RuleProperties<R, AK, S>): RuleProperties<R, AK, S>;
 
   /**
    * Searches for ArticleComment entities with extension properties that match the specified query.
@@ -1337,13 +1392,13 @@ export declare class ArticleComment extends BaseArticleComment {
  */
 export declare class BaseArticle extends BaseEntity {
   /**
-   * The original article from which the current article draft was created. Returns `null` if the current article is not an article draft.
+   * The article from which the current article draft was created, or `null` if the current article is not a draft.
    * @since 2026.1
    */
   readonly originalArticle: Article;
 
   /**
-   * If the current user has added the 'Star' tag to watch the article, this property is `true`.
+   * If the current user has added the 'Star' to watch the article, this property is `true`.
    * @since 2023.1
    */
   readonly isStarred: boolean;
@@ -2151,7 +2206,7 @@ export declare class Issue extends BaseEntity {
   readonly isResolved: boolean;
 
   /**
-   * If the current user has added the 'Star' tag to watch the issue, this property is `true`.
+   * If the current user has added the 'Star' to watch the issue, this property is `true`.
    */
   readonly isStarred: boolean;
 
@@ -2182,12 +2237,19 @@ export declare class Issue extends BaseEntity {
   readonly created: number;
 
   /**
+   * The customer groups this helpdesk ticket is shared with. Members of these groups can view the ticket and add public comments.
+   * @since 2026.2
+   */
+  readonly customerGroups: Set<UserGroup>;
+
+  /**
    * The text that is entered as the issue description.
    */
   description: string;
 
   /**
    * The collection of Gantt charts that this issue has been added to.
+   * @since 2022.1
    */
   readonly ganttCharts: Set<Gantt>;
 
@@ -2284,14 +2346,6 @@ export declare class Issue extends BaseEntity {
    * Plugged attributes for the issue. Used to store custom data from external integrations.
    */
   pluggedAttributes: { [key: string]: any };
-
-  /**
-   * Gantt charts that this issue belongs to.
-   */
-  readonly ganttCharts: {
-    added?: Set<GanttChart>;
-    removed?: Set<GanttChart>;
-  };
 
   /**
    * Common field: State. Available as a direct property for convenience.
@@ -2462,7 +2516,7 @@ export declare class Issue extends BaseEntity {
    * @param ruleProperties $ignore
    * @returns The object representation of the rule.
    */
-  static action<R extends Requirements = Requirements>(ruleProperties?: RuleProperties<R>): RuleProperties<R>;
+  static action<S extends Record<string, unknown> = Record<string, any>, R extends Requirements = Requirements, AK extends string = string>(ruleProperties?: RuleProperties<R, AK, S>): RuleProperties<R, AK, S>;
 
   /**
    * Creates a new issue draft.
@@ -2471,7 +2525,7 @@ export declare class Issue extends BaseEntity {
    * @param reporter Issue draft reporter.
    * @returns Newly created issue draft.
    */
-  static createDraft(project: Project, reporter: User): Issue;
+  static createDraft(project: Project, reporter?: User): Issue;
 
   /**
    * Creates a new shared issue draft.
@@ -2525,7 +2579,7 @@ export declare class Issue extends BaseEntity {
    * @param ruleProperties $ignore
    * @returns The object representation of the rule.
    */
-  static onChange<R extends Requirements = Requirements>(ruleProperties?: RuleProperties<R>): RuleProperties<R>;
+  static onChange<S extends Record<string, unknown> = Record<string, any>, R extends Requirements = Requirements, AK extends string = string>(ruleProperties?: RuleProperties<R, AK, S>): RuleProperties<R, AK, S>;
 
   /**
    * Creates a declaration of a rule that is triggered on a set schedule.
@@ -2552,7 +2606,7 @@ export declare class Issue extends BaseEntity {
    * @param ruleProperties $ignore
    * @returns The object representation of the rule.
    */
-  static onSchedule<R extends Requirements = Requirements>(ruleProperties?: RuleProperties<R>): RuleProperties<R>;
+  static onSchedule<S extends Record<string, unknown> = Record<string, any>, R extends Requirements = Requirements, AK extends string = string>(ruleProperties?: RuleProperties<R, AK, S>): RuleProperties<R, AK, S>;
 
   /**
    * Creates a declaration of a custom SLA policy. An SLA policy defines the time goals for the replies from staff and request resolution.
@@ -2595,7 +2649,7 @@ export declare class Issue extends BaseEntity {
    * @param ruleProperties $ignore
    * @returns The object representation of the SLA policy.
    */
-  static sla<R extends Requirements = Requirements>(ruleProperties?: RuleProperties<R>): RuleProperties<R>;
+  static sla<S extends Record<string, unknown> = Record<string, any>, R extends Requirements = Requirements, AK extends string = string>(ruleProperties?: RuleProperties<R, AK, S>): RuleProperties<R, AK, S>;
 
   /**
    * Creates a declaration of a state-machine rule. The state-machine imposes restrictions for the transitions between values in a custom field.
@@ -2652,13 +2706,13 @@ export declare class Issue extends BaseEntity {
    * @param ruleProperties $ignore
    * @returns The object representation of the rule.
    */
-  static stateMachine<R extends Requirements = Requirements>(ruleProperties?: RuleProperties<R>): RuleProperties<R>;
+  static stateMachine<S extends Record<string, unknown> = Record<string, any>, R extends Requirements = Requirements, AK extends string = string>(ruleProperties?: RuleProperties<R, AK, S>): RuleProperties<R, AK, S>;
 
   /**
    * Attaches a file to the issue.
    * Makes `issue.attachments.isChanged` return `true` for the current transaction.
    * @since 2019.2.53994
-   * @param content The content of the file in binary or base64 form.
+   * @param content The content of the file in binary form or as a base64 data URI. Base64 content must use the `data:[MIME type];base64,[content]` syntax.
    * @param name The name of the file.
    * @param charset The charset of the file. Only applicable to text files.
    * @param mimeType The MIME type of the file.
@@ -2692,7 +2746,7 @@ export declare class Issue extends BaseEntity {
    * @param type The work item type.
    * @returns The new work item.
    */
-  addWorkItem(description: string, date: number, author: User, duration: number, type: WorkItemType): IssueWorkItem;
+  addWorkItem(description: string, date?: number, author?: User, duration?: number, type?: WorkItemType): IssueWorkItem;
 
   /**
    * Adds the specified number of minutes to a specified starting point in time.
@@ -2722,7 +2776,7 @@ export declare class Issue extends BaseEntity {
    * @param project Project to create new issue in. Available since 2018.1.40575.
    * @returns The copy of the original issue.
    */
-  copy(project: Project): Issue;
+  copy(project?: Project): Issue;
 
   /**
    * Checks whether the specified tag is attached to an issue.
@@ -2730,7 +2784,7 @@ export declare class Issue extends BaseEntity {
    * @param ignoreVisibilitySettings When `true`, checks all matching tags without regard to their visibility settings. When `false` (default), checks only matching tags that are visible to the current user.
    * @returns If the specified tag is attached to the issue, returns `true`.
    */
-  hasTag(tagName: string, ignoreVisibilitySettings: boolean): boolean;
+  hasTag(tagName: string, ignoreVisibilitySettings?: boolean): boolean;
 
   /**
    * Checks whether the issue is accessible by specified user.
@@ -2897,7 +2951,7 @@ export declare class IssueAttachment extends PersistentFile {
    * @param ruleProperties $ignore
    * @returns The object representation of the rule.
    */
-  static action<R extends Requirements = Requirements>(ruleProperties?: RuleProperties<R>): RuleProperties<R>;
+  static action<S extends Record<string, unknown> = Record<string, any>, R extends Requirements = Requirements, AK extends string = string>(ruleProperties?: RuleProperties<R, AK, S>): RuleProperties<R, AK, S>;
 
   /**
    * Searches for IssueAttachment entities with extension properties that match the specified query.
@@ -3017,7 +3071,7 @@ export declare class IssueComment extends BaseComment {
    * @param ruleProperties $ignore
    * @returns The object representation of the rule.
    */
-  static action<R extends Requirements = Requirements>(ruleProperties?: RuleProperties<R>): RuleProperties<R>;
+  static action<S extends Record<string, unknown> = Record<string, any>, R extends Requirements = Requirements, AK extends string = string>(ruleProperties?: RuleProperties<R, AK, S>): RuleProperties<R, AK, S>;
 
   /**
    * Searches for IssueComment entities with extension properties that match the specified query.
@@ -3290,6 +3344,12 @@ export declare class Project extends BaseEntity {
   readonly fields: Set<ProjectCustomField>;
 
   /**
+   * The absolute URL of the project icon. Returns the custom uploaded icon when present, otherwise the generated default icon, or `null` when the icon URL cannot be produced.
+   * @since 2026.2
+   */
+  readonly iconUrl: string;
+
+  /**
    * The ID of the project. Use instead of project.shortName, which is deprecated.
    */
   readonly key: string;
@@ -3327,7 +3387,7 @@ export declare class Project extends BaseEntity {
   readonly sharedChangesProcessors: Set<ChangesProcessor>;
 
   /**
-   * A UserGroup object that contains the users and members of groups who are assigned to the project team.
+   * The project team. This UserGroup object contains the users and members of groups who are assigned to the project team.
    * @since 2017.4.38235
    */
   readonly team: UserGroup;
@@ -3354,6 +3414,12 @@ export declare class Project extends BaseEntity {
    * @since 2021.4.23500
    */
   readonly articles: Set<Article>;
+
+  /**
+   * The group that is set automatically as the initial default for the Visible to group in new issues and articles in this project.
+   * @since 2026.2
+   */
+  readonly defaultVisibilityGroup: UserGroup;
 
   /**
    * The description of the project as shown on the project profile page.
@@ -3445,7 +3511,7 @@ export declare class Project extends BaseEntity {
    * @param reporter Issue draft reporter.
    * @returns Newly created issue draft.
    */
-  newDraft(reporter: User): Issue;
+  newDraft(reporter?: User): Issue;
 
 }
 
@@ -3542,7 +3608,7 @@ export declare class ProjectCustomField extends BaseEntity {
 }
 
 /**
- * Represents a project team.
+ * Represents a project team. To access a project team in a workflow, use the `team` property of a `Project` object, such as `ctx.issue.project.team`, or the `teams` property of a `User` object. In rule requirements, reference a project team as a `UserGroup` by name.
  */
 export declare class ProjectTeam extends UserGroup {
   /**
@@ -3573,12 +3639,12 @@ export declare class ProjectType extends BaseEntity {
   /**
    * Identifies a standard project for issue tracking.
    */
-  readonly DEFAULT: ProjectType;
+  static readonly DEFAULT: ProjectType;
 
   /**
    * Identifies a helpdesk project for managing tickets.
    */
-  readonly HELPDESK: ProjectType;
+  static readonly HELPDESK: ProjectType;
 
   /**
    * Name of the project type.
@@ -3710,17 +3776,17 @@ export declare class PullRequestState extends BaseEntity {
   /**
    * The pull request was declined.
    */
-  readonly DECLINED: PullRequestState;
+  static readonly DECLINED: PullRequestState;
 
   /**
    * The pull request was merged.
    */
-  readonly MERGED: PullRequestState;
+  static readonly MERGED: PullRequestState;
 
   /**
    * The pull request is open.
    */
-  readonly OPEN: PullRequestState;
+  static readonly OPEN: PullRequestState;
 
   /**
    * Name of the pull request state.
@@ -3973,7 +4039,7 @@ export declare class Tag extends WatchFolder {
    * @param ignoreVisibilitySettings When `true`, returns all matching tags without regard to their visibility settings. When `false` (default), returns only matching tags that are visible to the current user.
    * @returns The set of tags that match the specified name.
    */
-  static findByName(name: string, ignoreVisibilitySettings: boolean): Set<Tag>;
+  static findByName(name: string, ignoreVisibilitySettings?: boolean): Set<Tag>;
 
   /**
    * Finds tags owned by a specified user without considering the visibility settings for the tags.
@@ -3985,7 +4051,6 @@ export declare class Tag extends WatchFolder {
 
   /**
    * Finds the most relevant tag with the specified name that is visible to the current user.
-   * "Star" tag is excluded from the results.
    * @param name The name of the tag to search for.
    * @returns The most relevant tag.
    */
@@ -4125,10 +4190,16 @@ export declare class User extends BaseEntity {
   readonly registered: number;
 
   /**
-   * The list of user's project teams.
+   * The list of project teams that the user belongs to.
    * @since 2025.3
    */
   readonly teams: Set<ProjectTeam>;
+
+  /**
+   * The user type assigned to the user account for licensing purposes. Possible values include: `UserType.STANDARD_USER` (a standard user), `UserType.AGENT` (a helpdesk agent), and `UserType.REPORTER` (a helpdesk reporter).
+   * @since 2026.2
+   */
+  readonly type: UserType;
 
 
   /**
@@ -4226,15 +4297,15 @@ export declare class User extends BaseEntity {
    * @param project The project to check for the specified permission assignment. If omitted, checks if the user has the global role.
    * @returns If the user has the permission, returns `true`.
    */
-  hasPermission(permissionKey: string, project: Project): boolean;
+  hasPermission(permissionKey: string, project?: Project): boolean;
 
   /**
    * Checks whether the user is granted the specified role in the specified project. When the project parameter is not specified, checks whether the user has the specified role in any project.
    * @param roleName The name of the role to check for.
-   * @param project The project to check for the specified role assignment. If omitted, checks if the user has the global role.
+   * @param project The project to check for the specified role assignment. If omitted, checks whether the user has the specified role in any project.
    * @returns If the user is granted the specified role, returns `true`.
    */
-  hasRole(roleName: string, project: Project): boolean;
+  hasRole(roleName: string, project?: Project): boolean;
 
   /**
    * Checks whether the user is a member of the specified group.
@@ -4295,7 +4366,7 @@ export declare class User extends BaseEntity {
 
   /**
    * Removes the current user from the list of watchers for the article
-   * (removes the `Star` tag).
+   * (removes the `Star`).
    * @since 2023.1
    * @param article The article from which the user is removed as a watcher.
    */
@@ -4303,7 +4374,7 @@ export declare class User extends BaseEntity {
 
   /**
    * Removes the current user from the list of watchers for the issue
-   * (removes the `Star` tag).
+   * (removes the `Star`).
    * @param issue The issue from which the user is removed as a watcher.
    */
   unwatchIssue(issue: Issue): void;
@@ -4315,14 +4386,14 @@ export declare class User extends BaseEntity {
   voteIssue(issue: Issue): void;
 
   /**
-   * Adds the current user to the article as a watcher (adds the `Star` tag).
+   * Adds the current user to the article as a watcher (adds the `Star`).
    * @since 2023.1
    * @param article The article to which the user is added as a watcher.
    */
   watchArticle(article: BaseArticle): void;
 
   /**
-   * Adds the current user to the issue as a watcher (adds the `Star` tag).
+   * Adds the current user to the issue as a watcher (adds the `Star`).
    * @param issue The issue to which the user is added as a watcher.
    */
   watchIssue(issue: Issue): void;
@@ -4363,6 +4434,12 @@ export declare class UserGroup extends BaseEntity {
   readonly users: Set<User>;
 
   /**
+   * The set of helpdesk projects where this group is configured as a customer group. For groups that are not customer groups, this property is an empty set.
+   * @since 2026.2
+   */
+  readonly customerGroupProjects: Set<Project>;
+
+  /**
    * The description of the group.
    */
   readonly description: string;
@@ -4371,6 +4448,12 @@ export declare class UserGroup extends BaseEntity {
    * If the group is the All Users group, this property is `true`.
    */
   readonly isAllUsersGroup: boolean;
+
+  /**
+   * If this group is a helpdesk customer group, this property is `true`.
+   * @since 2026.2
+   */
+  readonly isCustomerGroup: boolean;
 
   /**
    * The name of the group.
@@ -4476,6 +4559,34 @@ export declare class UserProjectCustomField extends ProjectCustomField {
    * @returns If the value can be used for the issue, returns `true`.
    */
   isValuePermittedInIssue(issue: Issue, value: User): boolean;
+
+}
+
+/**
+ * Represents a classification that defines access to advanced helpdesk features and are used to regulate the pricing associated with each user account in YouTrack.
+ * @since 2026.2
+ */
+export declare class UserType extends BaseEntity {
+  /**
+   * Identifies an agent in a helpdesk project.
+   */
+  static readonly AGENT: UserType;
+
+  /**
+   * Identifies a reporter who can submit tickets in helpdesk projects.
+   */
+  static readonly REPORTER: UserType;
+
+  /**
+   * Identifies a standard user account.
+   */
+  static readonly STANDARD_USER: UserType;
+
+  /**
+   * Name of the user type.
+   * @since 2026.2
+   */
+  readonly typeName: string;
 
 }
 


### PR DESCRIPTION
JT-96765 align async surface with R-first, type-only stubs. Syncs the bundled youtrack-workflow-types stubs and the withStore curry with the upstream JT-96565 decisions, keeping the published surface additive and runtime-safe. 

- Stubs in types workflowTypeScriptStubs, apps and ai-tools d.ts: rule factories back to R-first R, AK, S; removed the callable defineHttpHandler and defineAITool since the module is type-only; store schemas constrained to Record of keyof S to AsyncStoreValue. 
- withStore: S constrained to Record of keyof S to AsyncStoreValue in both overloads, and it remains the single runtime identity for the store and async surface.
- Regression fixtures: rule-requirements-generics and action-ctx-async-split use the explicit R-first form and add back-compat onChange of R and nested-object rejection cases; define-aitool-plain rewritten onto satisfies plus withStore. typecheck regression, typecheck types, build and test dx all green.