### PR TITLE
fix(apps-tools): add jest-util as explicit devDependency

### DIFF
--- a/packages/apps-tools/package.json
+++ b/packages/apps-tools/package.json
@@ -130,6 +130,7 @@
     "eslint-config-prettier": "^9.1.0",
     "globals": "^15.9.0",
     "jest": "^29.7.0",
+    "jest-util": "^29.7.0",
     "nock": "13.5.5",
     "prettier": "3.3.3",
     "ts-jest": "^29.2.4",


### PR DESCRIPTION
`ts-jest` does a bare `require('jest-util')` at startup but npm wasn't hoisting it to a resolvable path — only nested deep inside jest's own `node_modules`. Adding it explicitly fixes the CLI test suite failure in CI.