### PR TITLE
fix(apps-tools): update documentation test to match renamed README section

### DIFF
--- a/packages/apps-tools/src/cli/documentation.test.ts
+++ b/packages/apps-tools/src/cli/documentation.test.ts
@@ -6,7 +6,7 @@ import {registeredCommandNames} from './index.js';
 describe('README command list', () => {
   it('documents exactly the commands registered by the CLI', () => {
     const readme = readReadme();
-    const utilityScripts = readme.match(/^## Utility Scripts\n([\s\S]*?)(?=^### )/m)?.[1];
+    const utilityScripts = readme.match(/^## CLI commands\n([\s\S]*?)(?=^### )/m)?.[1];
 
     expect(utilityScripts).toBeDefined();
 


### PR DESCRIPTION
PR #77 renamed `## Utility Scripts` to `## CLI commands` in the README but didn't update the test regex, causing the doc-completeness guard to always fail.