### PR TITLE
Declare permissions on the article feedback statistics endpoint

### DIFF
--- a/packages/article-feedback/public/backend.js
+++ b/packages/article-feedback/public/backend.js
@@ -1,13 +1,16 @@
+// An extension property that was never written reads as undefined, and
+// JSON.parse(undefined) parses the string "undefined" and throws, so the
+// nullish fallbacks below are only reachable if the parse gets valid JSON.
 function getFeedback(ctx) {
-  return JSON.parse(ctx.article.extensionProperties.feedback) ?? [];
+  return JSON.parse(ctx.article.extensionProperties.feedback || 'null') ?? [];
 }
 
 function getGuestFeedback(ctx) {
-  return JSON.parse(ctx.article.extensionProperties.guestFeedback) ?? [];
+  return JSON.parse(ctx.article.extensionProperties.guestFeedback || 'null') ?? [];
 }
 
 function getGuestLikes(ctx) {
-  return Number(JSON.parse(ctx.article.extensionProperties.guestLikes) ?? 0);
+  return Number(JSON.parse(ctx.article.extensionProperties.guestLikes || 'null') ?? 0);
 }
 
 function isGuest(ctx) {
@@ -52,19 +55,6 @@ function response(ctx, data) {
 
 exports.httpHandler = {
   endpoints: [
-    {
-      scope: 'article',
-      method: 'GET',
-      path: 'debug',
-      handle: function handleDebug(ctx) {
-        response(ctx, {
-          feedback: getFeedback(ctx),
-          guestFeedback: getGuestFeedback(ctx),
-          guestLikes: getGuestLikes(ctx)
-        });
-      }
-    },
-
     {
       scope: 'article',
       method: 'GET',
@@ -153,6 +143,9 @@ exports.httpHandler = {
       scope: 'article',
       method: 'GET',
       path: 'stat',
+      // Article scope only gates readability, so the endpoint must declare the
+      // same permission as the feedback-statistics widget in manifest.json.
+      permissions: ['UPDATE_ARTICLE'],
       handle: function handleStat(ctx) {
         const feedback = getFeedback(ctx);
         const guestFeedback = getGuestFeedback(ctx);
@@ -169,8 +162,15 @@ exports.httpHandler = {
         const likes = [...lastFeedbackOfEachUser, ...lastFeedbackOfEachGuest].filter(it => it.liked).length;
         const dislikes = [...lastFeedbackOfEachUser, ...lastFeedbackOfEachGuest].filter(it => !it.liked).length;
 
-        const messages = feedback.filter(it => it.message);
-        const guestMessages = guestFeedback.filter(it => it.message);
+        // ponytail: explicit field projection, so a field added to the stored
+        // records later is not served here until someone adds it on purpose.
+        const messages = feedback.
+          filter(it => it.message).
+          map(({userId, message, timestamp}) => ({userId, message, timestamp}));
+
+        const guestMessages = guestFeedback.
+          filter(it => it.message).
+          map(({name, email, message, timestamp}) => ({name, email, message, timestamp}));
 
         response(ctx, {likes, guestLikes, dislikes, messages, guestMessages});
       }

--- a/packages/article-feedback/widgets/api.ts
+++ b/packages/article-feedback/widgets/api.ts
@@ -91,10 +91,6 @@ export default class API {
     return this.hasPermission(READ_USER_PERMISSION);
   }
 
-  getDebug() {
-    return this.host.fetchApp('backend/debug', {scope: true});
-  }
-
   getUser() {
     return this.host.fetchApp('backend/user', {scope: true}) as Promise<User>;
   }


### PR DESCRIPTION
Part of [JT-97780](https://youtrack.jetbrains.com/issue/JT-97780).

The `stat` endpoint in `article-feedback` served aggregated feedback — reader-submitted messages and guest contact details — while declaring no handler permissions. Article scope only gates article *readability*, so the `UPDATE_ARTICLE` declared on the `feedback-statistics` widget in `manifest.json` governs widget rendering and never reaches the handler.

## Changes

- **`stat` declares `permissions: ['UPDATE_ARTICLE']`**, using the per-handler mechanism from JT-84011 (available since 2024.3.42652, so within the app's existing `minYouTrackVersion`).
- **Removed the `debug` endpoint** and its unused `Api.getDebug()` caller. It returned the stored records with no aggregation or filtering, and nothing in the widgets called it.
- **Explicit field projection in `stat`** instead of returning stored records verbatim, so a field added to storage later is not served until someone adds it deliberately. The pre-refactor version did this; it was lost along the way.
- **Guarded extension property parsing.** An unwritten property reads as `undefined`, and `JSON.parse(undefined)` parses the string `"undefined"` and throws, making the `?? []` fallbacks unreachable. This returned 500 from `user` and `stat` on any article with no feedback yet, which killed the form widget. `|| 'null'` also covers an empty-string property and matches the idiom in the app persistence docs.

## Verification

Against a local instance, admin token:

| endpoint | before | after |
|---|---|---|
| `user` | 500 | 200 |
| `stat` | 500 | 200, permission declared |
| `debug` | 200 | 404 |
| `project` | 200 | 200 |

Full round trip confirmed: submitting a like and a dislike with a message persists, and `stat` returns the projected field set.