### PR TITLE
fix(apps-tools): mark dist as ESM in generated package.json

### DIFF
--- a/packages/apps-tools/package.json
+++ b/packages/apps-tools/package.json
@@ -149,7 +149,7 @@
     "test:type": "tsc --noEmit",
     "typecheck:types": "tsc --noEmit -p src/dx/test/types-strict-tsconfig.json",
     "typecheck:regression": "tsc --noEmit -p src/dx/test/regression/regression-tsconfig.json",
-    "save-version": "echo '{ \"version\": \"'$npm_package_version'\" }' > dist/package.json",
+    "save-version": "echo '{ \"type\": \"module\", \"version\": \"'$npm_package_version'\" }' > dist/package.json",
     "release:ci": "commit-and-tag-version && git push --follow-tags origin main && npm run save-version && npm publish"
   },
   "commit-and-tag-version": {

--- a/packages/create-youtrack-app/package.json
+++ b/packages/create-youtrack-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jetbrains/create-youtrack-app",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A scaffolding utility that generates a YouTrack app",
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
Follow-up to #86 — that PR was merged at a stale head, so only the `create-youtrack-app` 1.0.0 bump landed. The actual fix never made it to `main`. This re-applies it.