### PR TITLE
Fix root skill documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This monorepo contains the tools, agent guidance, and example apps used to build and manage YouTrack apps.
 
-- **[YouTrack Apps skill](packages/create-youtrack-app/README.md#install-the-agent-skill)** — guides coding agents through creating, changing, and managing YouTrack apps, and directs them to the two CLIs below.
+- **[YouTrack Apps skill](skills/README.md)** — guides coding agents through creating, changing, and managing YouTrack apps, and directs them to the two CLIs below.
 - **[`create-youtrack-app` CLI](packages/create-youtrack-app/README.md)** — start here to scaffold a JavaScript or TypeScript app, then add widgets, handlers, settings, extension properties, and workflow rules. TypeScript apps use the Enhanced DX workflow and include the `youtrack-app` tools.
 - **[`youtrack-app` CLI](packages/apps-tools/README.md)** — manage an app in a YouTrack instance: upload, download, validate, configure, inspect, and troubleshoot it. It also provides safe exploration commands for YouTrack data and a raw REST request command.
 - **[Open-source apps](packages/)** — A collection of JetBrains-developed apps showcasing manifests, widgets, workflows, and tooling for building and uploading them.


### PR DESCRIPTION
Updates the root README to link directly to the new skill documentation.

This keeps the repository entry point aligned with the merged skill README.

Checks: `git diff --check`.