### PR TITLE
Unify YouTrack token environment variables

### DIFF
--- a/packages/apps-tools/README.md
+++ b/packages/apps-tools/README.md
@@ -60,9 +60,10 @@ The package includes scripts for synchronizing local changes with your YouTrack.
 `youtrack-app` also reads the following environment variables:
 
 - `YOUTRACK_HOST` - Your YouTrack instance URL.
-- `YOUTRACK_API_TOKEN` - Your permanent token for accessing the YouTrack API.
+- `YOUTRACK_TOKEN` - Your permanent token for accessing the YouTrack API.
+- `YOUTRACK_API_TOKEN` - Legacy alias for `YOUTRACK_TOKEN`.
 
-Configure these variables once, or pass `--host` and `--token` to each command. If you provide both environment variables and command-line arguments, the command-line arguments take precedence.
+Configure these variables once, or pass `--host` and `--token` to each command. `YOUTRACK_TOKEN` takes precedence over `YOUTRACK_API_TOKEN`; command-line arguments take precedence over both.
 
 ### Language Support
 

--- a/packages/apps-tools/src/cli/index.test.ts
+++ b/packages/apps-tools/src/cli/index.test.ts
@@ -44,6 +44,7 @@ describe('index', function () {
     nock.disableNetConnect();
     jest.spyOn(console, 'log').mockImplementation(() => {});
     process.env.YOUTRACK_HOST = '';
+    process.env.YOUTRACK_TOKEN = '';
     process.env.YOUTRACK_API_TOKEN = '';
   });
 
@@ -55,6 +56,14 @@ describe('index', function () {
   it('should print version', function () {
     require('./index').run(['', '', '--version']);
     expect(console.log).toHaveBeenCalledWith(require('../../package.json').version);
+  });
+
+  it('should mention the legacy token fallback in help', function () {
+    require('./index').run(['', '', '--help']);
+
+    expect(console.log).toHaveBeenCalledWith(
+      'Set YOUTRACK_HOST and YOUTRACK_TOKEN (or YOUTRACK_API_TOKEN), or provide --host and --token with each command.',
+    );
   });
 
   it('should show error message if required parameter doesn`t have value', function () {
@@ -124,6 +133,25 @@ describe('index', function () {
     expect(list).toHaveBeenCalledWith(expectedCallArgs, undefined);
     expect(console.error).not.toHaveBeenCalled();
     expect(process.exit).not.toHaveBeenCalled();
+  });
+
+  it('should use YOUTRACK_TOKEN before the legacy YOUTRACK_API_TOKEN', function () {
+    process.env.YOUTRACK_HOST = 'foo';
+    process.env.YOUTRACK_TOKEN = 'preferred-token';
+    process.env.YOUTRACK_API_TOKEN = 'legacy-token';
+
+    require('./index').run(['', '', 'app', 'list']);
+
+    expect(list).toHaveBeenCalledWith(expect.objectContaining({host: 'foo', token: 'preferred-token'}), undefined);
+  });
+
+  it('should use YOUTRACK_API_TOKEN when YOUTRACK_TOKEN is not set', function () {
+    process.env.YOUTRACK_HOST = 'foo';
+    process.env.YOUTRACK_API_TOKEN = 'legacy-token';
+
+    require('./index').run(['', '', 'app', 'list']);
+
+    expect(list).toHaveBeenCalledWith(expect.objectContaining({host: 'foo', token: 'legacy-token'}), undefined);
   });
 
   it('should pass yaml flag to commands', function () {

--- a/packages/apps-tools/src/cli/index.ts
+++ b/packages/apps-tools/src/cli/index.ts
@@ -157,10 +157,10 @@ export async function run(argv = process.argv) {
     return;
   }
 
-  const {YOUTRACK_HOST, YOUTRACK_API_TOKEN} = process.env;
+  const {YOUTRACK_HOST, YOUTRACK_TOKEN, YOUTRACK_API_TOKEN} = process.env;
   const config: Config = {
     host: args.host || YOUTRACK_HOST || null,
-    token: args.token || YOUTRACK_API_TOKEN || null,
+    token: args.token || YOUTRACK_TOKEN || YOUTRACK_API_TOKEN || null,
     output: args.output || (commandKey === 'app:download' ? process.cwd() : null),
     overwrite: isFlagEnabled(args.overwrite) ? 'true' : null,
     manifest: args.manifest || null,
@@ -193,12 +193,12 @@ export async function run(argv = process.argv) {
     console.log('youtrack-app <entity> <action> [options]');
     br();
     console.log('Manage, configure, and debug YouTrack apps and workflows from an external development environment.');
-    console.log('Set YOUTRACK_HOST and YOUTRACK_API_TOKEN, or provide --host and --token with each command.');
+    console.log('Set YOUTRACK_HOST and YOUTRACK_TOKEN (or YOUTRACK_API_TOKEN), or provide --host and --token with each command.');
     br();
 
     printSection('Common options');
     printLine('--host <url>', 'YouTrack URL. Overrides YOUTRACK_HOST.');
-    printLine('--token <token>', 'Permanent token. Overrides YOUTRACK_API_TOKEN.');
+    printLine('--token <token>', 'Permanent token. Overrides YOUTRACK_TOKEN and YOUTRACK_API_TOKEN.');
     printLine('--json', 'Output results as machine-readable JSON, when supported.');
     printLine('--yaml, --yml', 'Output results as machine-readable YAML, when supported.');
     printLine('--help, -h', 'Show help information.');

--- a/packages/apps-tools/src/dx/upload-coordinator.ts
+++ b/packages/apps-tools/src/dx/upload-coordinator.ts
@@ -211,11 +211,11 @@ export class UploadCoordinator {
 
     const env = await loadDotEnv(path.resolve(this.cwd, '.env'));
     const host = env.YOUTRACK_HOST || process.env.YOUTRACK_HOST;
-    const token = env.YOUTRACK_TOKEN || process.env.YOUTRACK_API_TOKEN || process.env.YOUTRACK_TOKEN;
+    const token = env.YOUTRACK_TOKEN || process.env.YOUTRACK_TOKEN || process.env.YOUTRACK_API_TOKEN;
 
     if (!host || !token) {
       throw new Error(
-        'YOUTRACK_HOST and YOUTRACK_TOKEN must be defined either in .env (in the working directory) or in the process environment.'
+        'Define YOUTRACK_HOST and YOUTRACK_TOKEN in .env or the process environment. YOUTRACK_API_TOKEN is also supported in the process environment.'
       );
     }
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -44,7 +44,7 @@ You need Node.js 20.18.0 or later. To use `youtrack-app` directly, install it an
 
 ```bash
 export YOUTRACK_HOST=https://your-instance.youtrack.cloud
-export YOUTRACK_API_TOKEN=<your-permanent-token>
+export YOUTRACK_TOKEN=<your-permanent-token>
 ```
 
 Create the permanent token in **YouTrack → Profile → Account Security → New token**. Never commit it in Git.

--- a/skills/youtrack-apps-skill/SKILL.md
+++ b/skills/youtrack-apps-skill/SKILL.md
@@ -18,7 +18,7 @@ Verify these requirements once near the start of the session before using this s
 | npm | Run `npm --version`. Use the version bundled with Node.js `>= 24`, unless the app project declares a stricter version. |
 | npx | Run `npx --version`. Use the version bundled with npm, unless the app project declares a stricter version. |
 | `create-youtrack-app` CLI | Run `npx @jetbrains/create-youtrack-app@latest --help`. If it cannot run, read [references/cli-setup.md](references/cli-setup.md). |
-| `youtrack-app` CLI | Run `youtrack-app --help`. If missing, read [references/cli-setup.md](references/cli-setup.md). Commands that contact YouTrack also require a target host (`YOUTRACK_HOST`) and API token (`YOUTRACK_API_TOKEN`). If token variables are not in environment then read the article on how to obtain the token and instruct the user: [Manage Permanent Tokens](https://www.jetbrains.com/help/youtrack/server/manage-permanent-token.html#obtain-permanent-token). Never print token values. |
+| `youtrack-app` CLI | Run `youtrack-app --help`. If missing, read [references/cli-setup.md](references/cli-setup.md). Commands that contact YouTrack also require a target host (`YOUTRACK_HOST`) and token (`YOUTRACK_TOKEN`; `YOUTRACK_API_TOKEN` is also supported). If token variables are not in environment then read the article on how to obtain the token and instruct the user: [Manage Permanent Tokens](https://www.jetbrains.com/help/youtrack/server/manage-permanent-token.html#obtain-permanent-token). Never print token values. |
 
 If required tooling is missing and cannot be installed in the current environment, ask the
 user before continuing with a reduced local-only workflow.

--- a/skills/youtrack-apps-skill/references/cli-setup.md
+++ b/skills/youtrack-apps-skill/references/cli-setup.md
@@ -32,7 +32,7 @@ Commands that contact YouTrack need an instance URL and a permanent token with a
 
 ```bash
 export YOUTRACK_HOST=https://youtrack.example.com
-export YOUTRACK_API_TOKEN=<your-permanent-token>
+export YOUTRACK_TOKEN=<your-permanent-token>
 ```
 
-`youtrack-app` also accepts `--host` and `--token` for a one-off command. Generated Enhanced DX projects commonly store `YOUTRACK_HOST` and `YOUTRACK_TOKEN` in a local, uncommitted `.env` file; their upload script passes those values to the CLI explicitly.
+`youtrack-app` also accepts `--host` and `--token` for a one-off command. `YOUTRACK_API_TOKEN` remains supported as a fallback. Generated Enhanced DX projects commonly store `YOUTRACK_HOST` and `YOUTRACK_TOKEN` in a local, uncommitted `.env` file; their upload script passes those values to the CLI explicitly.


### PR DESCRIPTION
## What changed

- Made `YOUTRACK_TOKEN` the preferred token variable for `youtrack-app` and Enhanced DX uploads.
- Kept `YOUTRACK_API_TOKEN` as a compatibility fallback.
- Documented the precedence: `--token`, then `YOUTRACK_TOKEN`, then `YOUTRACK_API_TOKEN`.

## Why

The two CLI workflows used different environment variable names for the same permanent token. Using one primary name lets the same shell environment and generated project configuration work with both workflows without breaking existing `YOUTRACK_API_TOKEN` setups.

## Validation

- `npm run test:cli --workspace @jetbrains/youtrack-apps-tools -- index.test.ts`
- `npm run test:dx --workspace @jetbrains/youtrack-apps-tools`
- `npm run build --workspace @jetbrains/youtrack-apps-tools`
- `git diff --check`
