### PR TITLE
Bump YouTrack Apps skill to 1.0.2

### DIFF
--- a/skills/youtrack-apps-skill/SKILL.md
+++ b/skills/youtrack-apps-skill/SKILL.md
@@ -2,7 +2,7 @@
 name: youtrack-apps-skill
 description: Guides building, debugging, extending, and managing JetBrains YouTrack apps and workflows. Used when scaffolding, modifying, validating, uploading, downloading, enabling, disabling, or inspecting a YouTrack app, workflow rule, app endpoint, or manifest. Also use when creating GitHub release automation or publishing a YouTrack app to JetBrains Marketplace.
 metadata:
-  version: 1.0.1
+  version: 1.0.2
   YouTrackVersion: 2026.2.18243
 ---
 


### PR DESCRIPTION
## What changed

Bumped the YouTrack Apps skill metadata version from `1.0.1` to `1.0.2`.

## Validation

- Verified the skill frontmatter contains `version: 1.0.2`.
- `git diff --check`
